### PR TITLE
Fix grep exit code 1 in trusted config fetch

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -69,7 +69,7 @@ jobs:
               # Convert glob to proper regex: escape dots, then replace * with [^/]*
               pattern="${config_file//./\\.}"
               pattern="${pattern//\*/[^/]*}"
-              git ls-tree -r --name-only trusted-branch | grep -E "^${pattern}$" | while read -r file; do
+              git ls-tree -r --name-only trusted-branch | { grep -E "^${pattern}$" || true; } | while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from $BASE_REF branch"
                   mkdir -p "$(dirname "$file")"
@@ -140,7 +140,7 @@ jobs:
               # Convert glob to proper regex: escape dots, then replace * with [^/]*
               pattern="${config_file//./\\.}"
               pattern="${pattern//\*/[^/]*}"
-              git ls-tree -r --name-only trusted-branch | grep -E "^${pattern}$" | while read -r file; do
+              git ls-tree -r --name-only trusted-branch | { grep -E "^${pattern}$" || true; } | while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from $BASE_REF branch"
                   mkdir -p "$(dirname "$file")"
@@ -380,7 +380,7 @@ jobs:
               # Convert glob to proper regex: escape dots, then replace * with [^/]*
               pattern="${config_file//./\\.}"
               pattern="${pattern//\*/[^/]*}"
-              git ls-tree -r --name-only trusted-branch | grep -E "^${pattern}$" | while read -r file; do
+              git ls-tree -r --name-only trusted-branch | { grep -E "^${pattern}$" || true; } | while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from $BASE_REF branch"
                   mkdir -p "$(dirname "$file")"
@@ -563,7 +563,7 @@ jobs:
               # Convert glob to proper regex: escape dots, then replace * with [^/]*
               pattern="${config_file//./\\.}"
               pattern="${pattern//\*/[^/]*}"
-              git ls-tree -r --name-only trusted-branch | grep -E "^${pattern}$" | while read -r file; do
+              git ls-tree -r --name-only trusted-branch | { grep -E "^${pattern}$" || true; } | while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from $BASE_REF branch"
                   mkdir -p "$(dirname "$file")"
@@ -796,7 +796,7 @@ jobs:
               # Convert glob to proper regex: escape dots, then replace * with [^/]*
               pattern="${config_file//./\\.}"
               pattern="${pattern//\*/[^/]*}"
-              git ls-tree -r --name-only trusted-branch | grep -E "^${pattern}$" | while read -r file; do
+              git ls-tree -r --name-only trusted-branch | { grep -E "^${pattern}$" || true; } | while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from $BASE_REF branch"
                   mkdir -p "$(dirname "$file")"
@@ -916,7 +916,7 @@ jobs:
               # Convert glob to proper regex: escape dots, then replace * with [^/]*
               pattern="${config_file//./\\.}"
               pattern="${pattern//\*/[^/]*}"
-              git ls-tree -r --name-only trusted-branch | grep -E "^${pattern}$" | while read -r file; do
+              git ls-tree -r --name-only trusted-branch | { grep -E "^${pattern}$" || true; } | while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from $BASE_REF branch"
                   mkdir -p "$(dirname "$file")"


### PR DESCRIPTION
## Summary
- Wrap `grep -E` in `{ ... || true; }` in the trusted config fetch step across all jobs
- Without this, when no files match a glob pattern (e.g. `*.globalconfig`, `*.ruleset`), `grep` returns exit code 1 which kills the step under `bash -e -o pipefail`
- This was causing Stage 2a (Windows) to fail on all open PRs

## Test plan
- [ ] Verify Stage 2a Windows tests pass after merge
- [ ] Verify trusted config files that DO exist are still copied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)