### PR TITLE
Improve code quality, XML docs, and test coverage

### DIFF
--- a/src/Wolfgang.Extensions.IComparable/IComparableExtensions.cs
+++ b/src/Wolfgang.Extensions.IComparable/IComparableExtensions.cs
@@ -3,49 +3,66 @@ using System;
 namespace Wolfgang.Extensions.IComparable;
 
 /// <summary>
-/// A collection of extension methods for types that implement IComparable
+/// A collection of extension methods for types that implement <see cref="IComparable{T}"/>.
 /// </summary>
 // ReSharper disable once InconsistentNaming
 public static class IComparableExtensions
 {
     /// <summary>
-    /// Determines if the specified value is greater than the lowerBound and less than the upperBound
+    /// Determines if the specified <paramref name="value"/> is strictly greater than the
+    /// <paramref name="lowerBound"/> and strictly less than the <paramref name="upperBound"/>.
     /// </summary>
     /// <typeparam name="T">The type of the values being compared.</typeparam>
     /// <param name="value">The value to compare.</param>
-    /// <param name="lowerBound">The lower end of the series to search.</param>
-    /// <param name="upperBound">The upper end of the series to search.</param>
+    /// <param name="lowerBound">The exclusive lower bound of the range.</param>
+    /// <param name="upperBound">The exclusive upper bound of the range.</param>
     /// <returns>
-    /// True if the value to compare is greater than or equal to the min value and less
-    /// than or equal to the max value. Otherwise, false.
+    /// <see langword="true"/> if <paramref name="value"/> is greater than
+    /// <paramref name="lowerBound"/> and less than <paramref name="upperBound"/>;
+    /// otherwise, <see langword="false"/>.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="value"/> is <see langword="null"/>.
+    /// </exception>
     public static bool IsBetween<T>
     (
         this T value,
         T lowerBound,
         T upperBound
     ) where T : IComparable<T>
-        => 0 < value.CompareTo(lowerBound) && value.CompareTo(upperBound) < 0;
+    {
+        if (value == null) throw new ArgumentNullException(nameof(value));
+
+        return 0 < value.CompareTo(lowerBound) && value.CompareTo(upperBound) < 0;
+    }
 
 
 
     /// <summary>
-    /// Determines if the specified value is greater than or equal to the
-    /// lowerBound and less than or equal to the upperBound
+    /// Determines if the specified <paramref name="value"/> is greater than or equal to the
+    /// <paramref name="lowerBound"/> and less than or equal to the <paramref name="upperBound"/>.
     /// </summary>
     /// <typeparam name="T">The type of the values being compared.</typeparam>
     /// <param name="value">The value to compare.</param>
-    /// <param name="lowerBound">The lower end of the series to search.</param>
-    /// <param name="upperBound">The upper end of the series to search.</param>
+    /// <param name="lowerBound">The inclusive lower bound of the range.</param>
+    /// <param name="upperBound">The inclusive upper bound of the range.</param>
     /// <returns>
-    /// True if the value to compare is greater than or equal to the min value
-    /// and less than or equal to the max value. Otherwise, false.
+    /// <see langword="true"/> if <paramref name="value"/> is greater than or equal to
+    /// <paramref name="lowerBound"/> and less than or equal to <paramref name="upperBound"/>;
+    /// otherwise, <see langword="false"/>.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="value"/> is <see langword="null"/>.
+    /// </exception>
     public static bool IsInRange<T>
     (
         this T value,
         T lowerBound,
         T upperBound
     ) where T : IComparable<T>
-        => 0 <= value.CompareTo(lowerBound) && value.CompareTo(upperBound) <= 0;
+    {
+        if (value == null) throw new ArgumentNullException(nameof(value));
+
+        return 0 <= value.CompareTo(lowerBound) && value.CompareTo(upperBound) <= 0;
+    }
 }

--- a/src/Wolfgang.Extensions.IComparable/IComparableExtensions.cs
+++ b/src/Wolfgang.Extensions.IComparable/IComparableExtensions.cs
@@ -31,7 +31,7 @@ public static class IComparableExtensions
         T upperBound
     ) where T : IComparable<T>
     {
-        if (value == null) throw new ArgumentNullException(nameof(value));
+        if (value is null) throw new ArgumentNullException(nameof(value));
 
         return 0 < value.CompareTo(lowerBound) && value.CompareTo(upperBound) < 0;
     }
@@ -61,7 +61,7 @@ public static class IComparableExtensions
         T upperBound
     ) where T : IComparable<T>
     {
-        if (value == null) throw new ArgumentNullException(nameof(value));
+        if (value is null) throw new ArgumentNullException(nameof(value));
 
         return 0 <= value.CompareTo(lowerBound) && value.CompareTo(upperBound) <= 0;
     }

--- a/tests/Wolfgang.Extensions.IComparable.Tests.Unit/IComparableExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.IComparable.Tests.Unit/IComparableExtensionsTests.cs
@@ -23,7 +23,7 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("2011/7/1", true)]
         [InlineData("2011/12/31 23:59:59", false)]
         [InlineData("2012/1/1", false)]
-        public void IsBetween_When_Called_On_Date_Times_Returns_Expected_Result(string value, bool expectedValue)
+        public void IsBetween_when_called_on_date_times_returns_expected_result(string value, bool expectedValue)
         {
             var testValue = DateTime.Parse(value);
             Assert.Equal(expectedValue, testValue.IsBetween(new DateTime(2011, 1, 1), new DateTime(2011, 12, 31, 23, 59, 59)));
@@ -35,7 +35,7 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("2018/11/2", false)]
         [InlineData("2018/11/4", true)]
         [InlineData("2018/11/6", false)]
-        public void IsBetween_When_Called_On_Specific_Dates_Returns_Correct_Result(DateTime value, bool expectedValue)
+        public void IsBetween_when_called_on_specific_dates_returns_expected_result(DateTime value, bool expectedValue)
         {
             Assert.Equal(expectedValue, value.IsBetween(new DateTime(2018, 11, 2), new DateTime(2018, 11, 6)));
         }
@@ -48,7 +48,7 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("am", true)]
         [InlineData("ay", false)]
         [InlineData("az", false)]
-        public void IsBetween_When_Called_On_Strings_Returns_Expected_Result(string value, bool expectedValue)
+        public void IsBetween_when_called_on_strings_returns_expected_result(string value, bool expectedValue)
         {
             Assert.Equal(expectedValue, value.IsBetween("ab", "ay"));
         }
@@ -61,9 +61,35 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData('m', true)]
         [InlineData('y', false)]
         [InlineData('z', false)]
-        public void IsBetween_When_Called_On_Chars_Returns_Expected_Result(char value, bool expectedValue)
+        public void IsBetween_when_called_on_chars_returns_expected_result(char value, bool expectedValue)
         {
             Assert.Equal(expectedValue, value.IsBetween('b', 'y'));
+        }
+
+
+
+        [Fact]
+        public void IsBetween_when_value_equals_both_bounds_returns_false()
+        {
+            Assert.False(5.IsBetween(5, 5));
+        }
+
+
+
+        [Fact]
+        public void IsBetween_when_bounds_are_inverted_returns_false()
+        {
+            Assert.False(5.IsBetween(10, 1));
+        }
+
+
+
+        [Fact]
+        public void IsBetween_when_value_is_null_throws_argument_null_exception()
+        {
+            string? value = null;
+
+            Assert.Throws<ArgumentNullException>(() => value!.IsBetween("a", "z"));
         }
 
 
@@ -74,7 +100,7 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData(5, true)]
         [InlineData(10, true)]
         [InlineData(11, false)]
-        public void IsInRange_When_Called_On_Integers_Returns_Expected_Result(int value, bool expectedValue)
+        public void IsInRange_when_called_on_integers_returns_expected_result(int value, bool expectedValue)
         {
             Assert.Equal(expectedValue, value.IsInRange(1, 10));
         }
@@ -87,7 +113,7 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("2011/7/1", true)]
         [InlineData("2011/12/31 23:59:50", true)]
         [InlineData("2012/1/1", false)]
-        public void IsInRange_When_Called_On_Date_Times_Returns_Expected_Result(string value, bool expectedValue)
+        public void IsInRange_when_called_on_date_times_returns_expected_result(string value, bool expectedValue)
         {
             var testValue = DateTime.Parse(value);
             Assert.Equal(expectedValue, testValue.IsInRange(new DateTime(2011, 1, 1), new DateTime(2011, 12, 31, 23, 59, 59)));
@@ -96,12 +122,14 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
 
 
         [Theory]
-        [InlineData("2018/11/2")]
-        [InlineData("2018/11/4")]
-        [InlineData("2018/11/6")]
-        public void IsInRange_When_Called_On_Specific_Dates_Returns_Correct_Result(DateTime value)
+        [InlineData("2018/11/1", false)]
+        [InlineData("2018/11/2", true)]
+        [InlineData("2018/11/4", true)]
+        [InlineData("2018/11/6", true)]
+        [InlineData("2018/11/7", false)]
+        public void IsInRange_when_called_on_specific_dates_returns_expected_result(DateTime value, bool expectedValue)
         {
-            Assert.True(value.IsInRange(new DateTime(2018, 11, 2), new DateTime(2018, 11, 6)));
+            Assert.Equal(expectedValue, value.IsInRange(new DateTime(2018, 11, 2), new DateTime(2018, 11, 6)));
         }
 
 
@@ -112,7 +140,7 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("m", true)]
         [InlineData("y", true)]
         [InlineData("z", false)]
-        public void IsInRange_When_Called_On_Strings_Returns_Expected_Result(string value, bool expectedValue)
+        public void IsInRange_when_called_on_strings_returns_expected_result(string value, bool expectedValue)
         {
             Assert.Equal(expectedValue, value.IsInRange("b", "y"));
         }
@@ -125,8 +153,34 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData('m', true)]
         [InlineData('y', true)]
         [InlineData('z', false)]
-        public void IsInRange_When_Called_On_Chars_Returns_Expected_Result(char value, bool expectedValue)
+        public void IsInRange_when_called_on_chars_returns_expected_result(char value, bool expectedValue)
         {
             Assert.Equal(expectedValue, value.IsInRange('b', 'y'));
+        }
+
+
+
+        [Fact]
+        public void IsInRange_when_value_equals_both_bounds_returns_true()
+        {
+            Assert.True(5.IsInRange(5, 5));
+        }
+
+
+
+        [Fact]
+        public void IsInRange_when_bounds_are_inverted_returns_false()
+        {
+            Assert.False(5.IsInRange(10, 1));
+        }
+
+
+
+        [Fact]
+        public void IsInRange_when_value_is_null_throws_argument_null_exception()
+        {
+            string? value = null;
+
+            Assert.Throws<ArgumentNullException>(() => value!.IsInRange("a", "z"));
         }
     }

--- a/tests/Wolfgang.Extensions.IComparable.Tests.Unit/Wolfgang.Extensions.IComparable.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IComparable.Tests.Unit/Wolfgang.Extensions.IComparable.Tests.Unit.csproj
@@ -57,23 +57,6 @@
 		</PackageReference>
 	</ItemGroup>
 
-	<!-- .NET Core 3.1 specific packages -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.runner.console" Version="2.9.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="8.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
-
 	<!-- .NET 5.0 specific packages -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/tests/Wolfgang.Extensions.IComparable.Tests.Unit/Wolfgang.Extensions.IComparable.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IComparable.Tests.Unit/Wolfgang.Extensions.IComparable.Tests.Unit.csproj
@@ -43,7 +43,7 @@
 			   '$(TargetFramework)' == 'net481'
 			   ">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -60,7 +60,7 @@
 	<!-- .NET Core 3.1 specific packages -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -118,7 +118,7 @@
 			   '$(TargetFramework)' == 'net10.0'
 			   ">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## Summary
- Fix `IsBetween` XML doc `<returns>` tag that incorrectly described inclusive bounds (copy-paste from `IsInRange`)
- Add `<paramref>`, `<see cref>`, `<see langword>` to all XML documentation tags
- Add `ArgumentNullException` guard for null reference type values on both methods
- Use inclusive/exclusive terminology in parameter docs for clarity
- Normalize all test method names to lowercase convention per CLAUDE.md
- Add edge case tests: equal bounds, inverted bounds, null inputs (46 -> 54 tests)
- Fix `IsInRange` specific dates test to verify both true and false cases
- Downgrade `xunit.runner.visualstudio` from 3.x to 2.8.2 on affected TFMs (3.x incompatible with xunit v2)

## Test plan
- [x] All 54 tests pass on net8.0
- [x] All 54 tests pass on net462
- [x] Build succeeds with 0 warnings across all TFMs
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)