### PR TITLE
Sync non-protected template configs, workflows, and code quality fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,49 @@
+# Auto detect text files and perform LF normalization
+* text=auto eol=lf
+
+# Source code
+*.cs text eol=lf
+*.csx text eol=lf
+*.vb text eol=lf
+*.fs text eol=lf
+*.fsx text eol=lf
+
+# Scripts
+# PowerShell scripts: CRLF line endings (intentional override)
+# PowerShell files use CRLF (Windows-style) line endings for convention compliance.
+*.ps1 text eol=crlf
+
+
+# Build and configuration files
+*.xml text eol=lf
+*.csproj text eol=lf
+*.vbproj text eol=lf
+*.fsproj text eol=lf
+*.sln text eol=lf
+*.slnx text eol=lf
+*.props text eol=lf
+*.targets text eol=lf
+*.ruleset text eol=lf
+*.config text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Documentation
+*.md text eol=lf
+*.txt text eol=lf
+
+# SVG files (XML-based text)
+*.svg text eol=lf
+
+# Denote all files that are truly binary and should not be modified
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.dll binary
+*.exe binary
+*.nupkg binary
+*.snupkg binary

--- a/.github/workflows/build-all-versions.yaml
+++ b/.github/workflows/build-all-versions.yaml
@@ -1,0 +1,349 @@
+name: Build All Versioned Docs
+
+# One-shot (or on-demand) workflow that builds DocFX documentation for every
+# v*.*.* git tag and deploys the output to gh-pages under versions/<version>/.
+# The version list is discovered automatically from git tags at runtime – no
+# manual updates are required when new releases are published.
+#
+# Versions without a docfx_project at their tag (e.g. v0.1.x) use the
+# current docfx_project configuration so that the documentation structure
+# is consistent across all versions.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read  # Default to read-only; the build-and-deploy job overrides with write
+
+jobs:
+  build-and-deploy:
+    name: Build & Deploy All Versioned Docs
+    runs-on: windows-latest
+
+    permissions:
+      contents: write # Required to push to gh-pages branch
+
+    steps:
+      - name: Checkout repository (full history + all tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history so all tags are reachable
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            5.0.x
+            6.0.x
+            7.0.x
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Install DocFX
+        run: |
+          dotnet tool update docfx --global || dotnet tool install docfx --global
+        shell: pwsh
+
+      - name: Build docs for each version
+        id: build
+        shell: pwsh
+        run: |
+          $outDir = Join-Path $env:RUNNER_TEMP 'all_version_docs'
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+          # Versions to build – discovered automatically from all v*.*.* git tags so
+          # no manual list updates are needed when new releases are published.
+          # 'latest' is handled separately below.
+          $semverRe = '^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>[0-9A-Za-z.-]+))?$'
+          $versions = @(
+            git tag -l 'v*' |
+              Where-Object { $_ -match $semverRe } |
+              ForEach-Object {
+                $_ -match $semverRe | Out-Null
+                $stable = if ([string]::IsNullOrEmpty($Matches['prerelease'])) { 1 } else { 0 }
+                [PSCustomObject]@{
+                  Tag    = $_
+                  Major  = [int]$Matches['major']
+                  Minor  = [int]$Matches['minor']
+                  Patch  = [int]$Matches['patch']
+                  Stable = $stable
+                }
+              } |
+              Sort-Object -Property Major, Minor, Patch, Stable -Descending |
+              Select-Object -ExpandProperty Tag
+          )
+          Write-Host "Discovered $($versions.Count) version tag(s): $($versions -join ', ')"
+
+          foreach ($version in $versions) {
+            Write-Host "========================================" -ForegroundColor Cyan
+            Write-Host "Building docs for $version" -ForegroundColor Cyan
+            Write-Host "========================================" -ForegroundColor Cyan
+
+            $workDir = Join-Path $env:RUNNER_TEMP "workdir-$version"
+
+            # Clean up any leftover worktree from a previous run
+            $removeOutput = git worktree remove $workDir --force 2>&1
+            if ($LASTEXITCODE -ne 0 -and (Test-Path $workDir)) {
+              Write-Warning "⚠️  Could not remove worktree for $version via git; attempting manual cleanup."
+              Remove-Item $workDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+
+            # Create a worktree checked out at the version tag
+            git worktree add $workDir $version
+            if ($LASTEXITCODE -ne 0) {
+              Write-Warning "⚠️  Failed to create worktree for $version – skipping."
+              continue
+            }
+
+            # Overlay the current docfx_project config so that older tags
+            # (which may lack docfx_project/) still produce consistent docs.
+            if (Test-Path 'docfx_project') {
+              if (Test-Path "$workDir/docfx_project") {
+                Remove-Item "$workDir/docfx_project" -Recurse -Force
+              }
+              Copy-Item 'docfx_project' "$workDir/docfx_project" -Recurse -Force
+            }
+
+            # Copy build-support files that were added in later versions to help
+            # older code compile cleanly.  These files contain global settings
+            # (analyzer rules, banned symbols) that are version-agnostic; copying
+            # them into older worktrees is safe and avoids restore/build warnings.
+            foreach ($f in @('Directory.Build.props', '.globalconfig', 'BannedSymbols.txt')) {
+              if ((Test-Path $f) -and -not (Test-Path "$workDir/$f")) {
+                Copy-Item $f "$workDir/$f" -Force -ErrorAction Stop
+              }
+            }
+            Push-Location $workDir
+            try {
+              # Attempt dotnet restore + build; failures are non-fatal because
+              # DocFX can still extract metadata from source files.
+              $slnFile = Get-ChildItem -File -ErrorAction SilentlyContinue |
+                         Where-Object { $_.Extension -in @('.sln', '.slnx') } |
+                         Select-Object -First 1
+              if ($slnFile) {
+                Write-Host "Restoring $($slnFile.Name)..."
+                dotnet restore $slnFile.FullName 2>&1 | Write-Host
+                Write-Host "Building $($slnFile.Name)..."
+                dotnet build $slnFile.FullName --configuration Release --no-restore 2>&1 | Write-Host
+              }
+
+              Write-Host "Running docfx metadata..."
+              docfx metadata docfx_project/docfx.json 2>&1 | Write-Host
+
+              Write-Host "Running docfx build..."
+              docfx build docfx_project/docfx.json 2>&1 | Write-Host
+
+              if (Test-Path 'docfx_project/_site') {
+                $dest = Join-Path $outDir 'versions' $version
+                New-Item -ItemType Directory -Force -Path $dest | Out-Null
+                Copy-Item 'docfx_project/_site/*' $dest -Recurse -Force -ErrorAction Stop
+                Write-Host "✅ Docs built for $version" -ForegroundColor Green
+              } else {
+                Write-Warning "⚠️  No _site output produced for $version."
+              }
+            } finally {
+              Pop-Location
+              $removeOutput = git worktree remove $workDir --force 2>&1
+              if ($LASTEXITCODE -ne 0) {
+                Write-Warning "⚠️  git worktree remove failed for $version (exit $LASTEXITCODE): $removeOutput"
+              }
+            }
+          }
+
+          # Build 'latest' from the most recent stable v*.*.* tag so that the
+          # 'latest' docs always match the last published release rather than an
+          # arbitrary HEAD commit.
+          Write-Host "========================================" -ForegroundColor Cyan
+          Write-Host "Building docs for latest" -ForegroundColor Cyan
+          Write-Host "========================================" -ForegroundColor Cyan
+
+          $semverRe = '^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$'
+          $latestTag = git tag -l 'v*' |
+            Where-Object { $_ -match $semverRe } |
+            ForEach-Object {
+              $_ -match $semverRe | Out-Null
+              [PSCustomObject]@{
+                Tag   = $_
+                Major = [int]$Matches['major']
+                Minor = [int]$Matches['minor']
+                Patch = [int]$Matches['patch']
+              }
+            } |
+            Sort-Object -Property Major, Minor, Patch -Descending |
+            Select-Object -First 1 -ExpandProperty Tag
+
+          if (-not $latestTag) {
+            Write-Error "❌ No stable v*.*.* tag found – cannot build 'latest'."
+            exit 1
+          }
+
+          Write-Host "Latest stable tag: $latestTag" -ForegroundColor Cyan
+
+          $latestWorkDir = Join-Path $env:RUNNER_TEMP 'workdir-latest'
+          $removeOutput = git worktree remove $latestWorkDir --force 2>&1
+          if ($LASTEXITCODE -ne 0 -and (Test-Path $latestWorkDir)) {
+            Remove-Item $latestWorkDir -Recurse -Force -ErrorAction SilentlyContinue
+          }
+
+          git worktree add $latestWorkDir $latestTag
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "❌ Failed to create worktree for $latestTag (latest)."
+            exit 1
+          }
+
+          # Overlay current docfx_project and build-support files (same as versioned builds)
+          if (Test-Path 'docfx_project') {
+            if (Test-Path "$latestWorkDir/docfx_project") {
+              Remove-Item "$latestWorkDir/docfx_project" -Recurse -Force
+            }
+            Copy-Item 'docfx_project' "$latestWorkDir/docfx_project" -Recurse -Force
+          }
+          foreach ($f in @('Directory.Build.props', '.globalconfig', 'BannedSymbols.txt')) {
+            if ((Test-Path $f) -and -not (Test-Path "$latestWorkDir/$f")) {
+              Copy-Item $f "$latestWorkDir/$f" -Force -ErrorAction Stop
+            }
+          }
+
+          Push-Location $latestWorkDir
+          try {
+            $slnFile = Get-ChildItem -File -ErrorAction SilentlyContinue |
+                       Where-Object { $_.Extension -in @('.sln', '.slnx') } |
+                       Select-Object -First 1
+            if ($slnFile) {
+              Write-Host "Restoring $($slnFile.Name)..."
+              dotnet restore $slnFile.FullName
+              if ($LASTEXITCODE -ne 0) {
+                Write-Warning "⚠️  dotnet restore failed for latest – continuing to docfx."
+              }
+              Write-Host "Building $($slnFile.Name)..."
+              dotnet build $slnFile.FullName --configuration Release --no-restore
+              if ($LASTEXITCODE -ne 0) {
+                Write-Warning "⚠️  dotnet build failed for latest – continuing to docfx."
+              }
+            }
+
+            Write-Host "Running docfx metadata..."
+            docfx metadata docfx_project/docfx.json
+            if ($LASTEXITCODE -ne 0) {
+              Write-Error "❌ docfx metadata failed for latest (exit $LASTEXITCODE)."
+              exit $LASTEXITCODE
+            }
+
+            Write-Host "Running docfx build..."
+            docfx build docfx_project/docfx.json
+            if ($LASTEXITCODE -ne 0) {
+              Write-Error "❌ docfx build failed for latest (exit $LASTEXITCODE)."
+              exit $LASTEXITCODE
+            }
+
+            if (Test-Path 'docfx_project/_site') {
+              $dest = Join-Path $outDir 'versions' 'latest'
+              New-Item -ItemType Directory -Force -Path $dest | Out-Null
+              Copy-Item 'docfx_project/_site/*' $dest -Recurse -Force -ErrorAction Stop
+              Write-Host "✅ Docs built for latest ($latestTag)" -ForegroundColor Green
+            } else {
+              Write-Error "❌ No _site output for latest build."
+              exit 1
+            }
+          } finally {
+            Pop-Location
+            $removeOutput = git worktree remove $latestWorkDir --force 2>&1
+            if ($LASTEXITCODE -ne 0) {
+              Write-Warning "⚠️  git worktree remove failed for latest (exit $LASTEXITCODE): $removeOutput"
+            }
+          }
+
+      - name: Generate versions.json for every version
+        # Writes a versions.json (consumed by the version-switcher dropdown) into
+        # each version's output directory.  All URLs are rooted under versions/.
+        shell: pwsh
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          $outDir = Join-Path $env:RUNNER_TEMP 'all_version_docs'
+
+          $repoName = ($env:GITHUB_REPOSITORY -split '/')[-1]
+          $base = if ($repoName) { "/$repoName/" } else { "/" }
+
+          $semverRe = '^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>[0-9A-Za-z.-]+))?$'
+          $tags = git tag -l 'v*' | Where-Object { $_ -ne '' }
+
+          $taggedVersions = foreach ($t in $tags) {
+            if ($t -match $semverRe) {
+              $stable = if ([string]::IsNullOrEmpty($Matches['prerelease'])) { 1 } else { 0 }
+              [PSCustomObject]@{
+                Tag    = $t
+                Major  = [int]$Matches['major']
+                Minor  = [int]$Matches['minor']
+                Patch  = [int]$Matches['patch']
+                Stable = $stable
+              }
+            }
+          }
+
+          $orderedTags = $taggedVersions |
+            Sort-Object -Property Major, Minor, Patch, Stable -Descending |
+            Select-Object -ExpandProperty Tag
+
+          [array]$versions = @([PSCustomObject]@{ version = 'latest'; url = "${base}versions/latest/" })
+          foreach ($t in $orderedTags) {
+            $versions += [PSCustomObject]@{ version = $t; url = "${base}versions/$t/" }
+          }
+
+          $versionsJson = ConvertTo-Json -InputObject $versions -Depth 3
+
+          Get-ChildItem -Path (Join-Path $outDir 'versions') -Directory | ForEach-Object {
+            $versionsJson | Set-Content -Path (Join-Path $_.FullName 'versions.json') -Encoding utf8NoBOM
+            Write-Host "Wrote versions.json to $($_.Name)/"
+          }
+
+          Write-Host "Generated versions.json with $($versions.Count) entries: $($versions | ForEach-Object { $_.version })"
+
+      - name: Generate root index.html
+        # Builds index.html from the shared template (.github/version-picker-template.html)
+        # so the page layout is maintained in one place and both this workflow and
+        # docfx.yaml produce identical markup.
+        shell: pwsh
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          $outDir = Join-Path $env:RUNNER_TEMP 'all_version_docs'
+
+          $repoName = ($env:GITHUB_REPOSITORY -split '/')[-1]
+          $title    = if ($repoName) { "$repoName Documentation" } else { "Documentation" }
+
+          $versionsJsonPath = Join-Path $outDir 'versions' 'latest' 'versions.json'
+          $versions = Get-Content $versionsJsonPath -Raw | ConvertFrom-Json
+
+          $listItems = foreach ($v in $versions) {
+            $liClass = if ($v.version -eq 'latest') { ' class="latest"' } else { '' }
+            $label   = if ($v.version -eq 'latest') { 'latest (stable)' } else { $v.version }
+            "      <li${liClass}><a href=`"$($v.url)`">$label</a></li>"
+          }
+          $listHtml = $listItems -join "`n"
+
+          $templatePath = '.github/version-picker-template.html'
+          if (-not (Test-Path $templatePath)) {
+            Write-Error "Template file '$templatePath' not found. This file is required."
+            exit 1
+          }
+          $template = Get-Content $templatePath -Raw
+          $html = $template -replace '\{\{TITLE\}\}', $title `
+                            -replace '\{\{VERSION_LIST\}\}', $listHtml
+
+          $html | Set-Content -Path (Join-Path $outDir 'index.html') -Encoding utf8NoBOM
+          Write-Host "Generated index.html with $($versions.Count) version link(s)."
+
+      - name: Deploy all versioned docs to gh-pages at root
+        # Publishes the entire all_version_docs/ output directory to gh-pages
+        # at the site root.  keep_files: true preserves any other content
+        # already present on the branch (CNAME, root assets, etc.).
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ runner.temp }}/all_version_docs
+          destination_dir: .
+          keep_files: true
+          force_orphan: false

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,186 @@
+name: "CodeQL Security Analysis"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read  # Default to read-only; the analyze job overrides where required
+
+jobs:
+  analyze:
+    name: "Security Scan (CodeQL)"
+    runs-on: windows-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Check for C# source code
+      id: check-csharp
+      shell: pwsh
+      run: |
+        Write-Host "=== CodeQL C# Source Code Detection ===" -ForegroundColor Cyan
+        Write-Host "Searching for C# source files using git index..." -ForegroundColor Cyan
+        
+        # Use git ls-files to efficiently find C# files (respects .gitignore and doesn't traverse excluded dirs)
+        $csharpFiles = @()
+        try {
+          $gitOutput = git ls-files '*.cs' '*.csproj' 2>$null
+          if ($LASTEXITCODE -eq 0) {
+            $csharpFiles = @($gitOutput | Where-Object { $_ })
+          } else {
+            Write-Warning "git ls-files failed with exit code $LASTEXITCODE. Falling back to filesystem search for C# files."
+          }
+        } catch {
+          Write-Warning "Exception while running git ls-files: $($_.Exception.Message). Falling back to filesystem search for C# files."
+        }
+
+        if (-not $csharpFiles -or $csharpFiles.Count -eq 0) {
+          Write-Host "git ls-files did not return any C# files. Scanning the filesystem for *.cs and *.csproj files..." -ForegroundColor Cyan
+          $csharpFiles = @(Get-ChildItem -Path . -Recurse -Include *.cs,*.csproj -File -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName)
+        }
+        $csharpFileCount = $csharpFiles.Count
+        
+        Write-Host "" -ForegroundColor Cyan
+        if ($csharpFileCount -eq 0) {
+          Write-Host "⚠️  No C# source code found." -ForegroundColor Yellow
+          Write-Host "   This appears to be an empty repository or a repository without projects." -ForegroundColor Yellow
+          Write-Host "   CodeQL analysis will be SKIPPED, but the job will complete successfully." -ForegroundColor Yellow
+          Write-Host "   This ensures branch protection requirements are met." -ForegroundColor Yellow
+          echo "has-csharp=false" >> $env:GITHUB_OUTPUT
+        } else {
+          Write-Host "✅ Found $csharpFileCount C# file(s)." -ForegroundColor Green
+          Write-Host "   CodeQL analysis will PROCEED." -ForegroundColor Green
+          echo "has-csharp=true" >> $env:GITHUB_OUTPUT
+        }
+        Write-Host "========================================" -ForegroundColor Cyan
+
+    - name: Initialize CodeQL
+      if: steps.check-csharp.outputs.has-csharp == 'true'
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Setup .NET
+      if: steps.check-csharp.outputs.has-csharp == 'true'
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '10.0.x'
+
+    - name: Build for CodeQL Analysis
+      id: build
+      if: steps.check-csharp.outputs.has-csharp == 'true'
+      shell: pwsh
+      run: |
+        Write-Host "Building solution for CodeQL analysis..."
+        
+        # Find solution file (.sln or .slnx)
+        $solution = Get-ChildItem -Path . -Recurse -Depth 2 -Include "*.sln", "*.slnx" | Select-Object -First 1
+        
+        if ($solution) {
+          Write-Host "Found solution: $($solution.FullName)"
+          dotnet restore $solution.FullName
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "dotnet restore failed with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }
+          dotnet build $solution.FullName --configuration Release --no-restore
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "dotnet build failed with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }
+        } else {
+          Write-Host "No solution file found, building all projects..."
+          dotnet restore
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "dotnet restore failed with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }
+          dotnet build --configuration Release --no-restore
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "dotnet build failed with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }
+        }
+        
+        Write-Host "✅ Build completed for CodeQL analysis"
+
+    - name: Perform CodeQL Analysis
+      id: perform-codeql-analysis
+      if: steps.check-csharp.outputs.has-csharp == 'true'
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"
+
+    - name: Complete Security Scan
+      if: always()
+      shell: pwsh
+      run: |
+        Write-Host "=== CodeQL Security Scan Complete ===" -ForegroundColor Cyan
+        
+        # Check the outcome of previous steps
+        $checkCsharpOutcome = "${{ steps.check-csharp.outcome }}"
+        $hasCsharp = "${{ steps.check-csharp.outputs.has-csharp }}"
+        $buildOutcome = "${{ steps.build.outcome }}"
+        $codeqlOutcome = "${{ steps.perform-codeql-analysis.outcome }}"
+        
+        # Determine overall status
+        $hasFailure = $false
+        $failureMessages = @()
+        
+        # Check if check-csharp step failed
+        if ($checkCsharpOutcome -eq "failure") {
+          $hasFailure = $true
+          $failureMessages += "❌ C# source code detection failed"
+        }
+        
+        # Check if build step failed (only relevant if C# code exists)
+        if ($hasCsharp -eq "true" -and $buildOutcome -eq "failure") {
+          $hasFailure = $true
+          $failureMessages += "❌ Build failed during CodeQL analysis"
+        }
+        
+        # Check if CodeQL analysis step failed (only relevant if C# code exists)
+        if ($hasCsharp -eq "true" -and $codeqlOutcome -eq "failure") {
+          $hasFailure = $true
+          $failureMessages += "❌ CodeQL analysis failed"
+        }
+        
+        # Display results based on actual step outcomes
+        if ($hasFailure) {
+          Write-Host "❌ Security scan completed with errors:" -ForegroundColor Red
+          foreach ($msg in $failureMessages) {
+            Write-Host "   $msg" -ForegroundColor Red
+          }
+          exit 1
+        } elseif ($hasCsharp -eq "true") {
+          Write-Host "✅ CodeQL analysis completed successfully." -ForegroundColor Green
+          Write-Host "   Results have been uploaded to GitHub Security." -ForegroundColor Green
+        } elseif ($hasCsharp -eq "false") {
+          Write-Host "✅ Security scan completed successfully (no C# code to analyze)." -ForegroundColor Green
+          Write-Host "   This job ran successfully and reports a passing status to branch protection." -ForegroundColor Green
+        } else {
+          Write-Host "✅ Security scan job completed." -ForegroundColor Green
+          Write-Host "   Job status reported to branch protection." -ForegroundColor Green
+        }
+        Write-Host "========================================" -ForegroundColor Cyan

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+# gitleaks configuration
+# https://github.com/gitleaks/gitleaks
+#
+# Add allowlist rules here to suppress false positives from test fixtures,
+# example configs, or documentation.
+
+title = "gitleaks config"
+
+[allowlist]
+  description = "Global allowlist"
+  paths = [
+    '''(^|/)tests?/.*fixtures?/''',
+    '''(^|/)tests?/.*testdata/''',
+  ]

--- a/examples/Wolfgang.Extensions.IComparable.DotNet462.Example1/Program.cs
+++ b/examples/Wolfgang.Extensions.IComparable.DotNet462.Example1/Program.cs
@@ -1,15 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System;
 
 namespace Wolfgang.Extensions.IComparable.DotNet462.Example1
 {
-    internal class Program
+    internal static class Program
     {
-        static void Main(string[] args)
+        private static void Main()
         {
+            Console.ForegroundColor = ConsoleColor.White;
+
+            var value = 1;
+            Console.WriteLine("   " + value + " IsBetween 1 and 10: " + value.IsBetween(1, 10));
+
+            value = 2;
+            Console.WriteLine("   " + value + " IsBetween 1 and 10: " + value.IsBetween(1, 10));
+
+            value = 9;
+            Console.WriteLine("   " + value + " IsBetween 1 and 10: " + value.IsBetween(1, 10));
+
+            value = 10;
+            Console.WriteLine("  " + value + " IsBetween 1 and 10: " + value.IsBetween(1, 10));
+
+            Console.WriteLine();
+
+            value = 1;
+            Console.WriteLine("   " + value + " IsInRange 1 and 10: " + value.IsInRange(1, 10));
+
+            value = 2;
+            Console.WriteLine("   " + value + " IsInRange 1 and 10: " + value.IsInRange(1, 10));
+
+            value = 9;
+            Console.WriteLine("   " + value + " IsInRange 1 and 10: " + value.IsInRange(1, 10));
+
+            value = 10;
+            Console.WriteLine("  " + value + " IsInRange 1 and 10: " + value.IsInRange(1, 10));
+
+            Console.WriteLine();
+
+            Console.ResetColor();
         }
     }
 }

--- a/src/Wolfgang.Extensions.IComparable/IComparableExtensions.cs
+++ b/src/Wolfgang.Extensions.IComparable/IComparableExtensions.cs
@@ -31,7 +31,10 @@ public static class IComparableExtensions
         T upperBound
     ) where T : IComparable<T>
     {
-        if (value is null) throw new ArgumentNullException(nameof(value));
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
 
         return 0 < value.CompareTo(lowerBound) && value.CompareTo(upperBound) < 0;
     }
@@ -61,7 +64,10 @@ public static class IComparableExtensions
         T upperBound
     ) where T : IComparable<T>
     {
-        if (value is null) throw new ArgumentNullException(nameof(value));
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
 
         return 0 <= value.CompareTo(lowerBound) && value.CompareTo(upperBound) <= 0;
     }

--- a/tests/Wolfgang.Extensions.IComparable.Tests.Unit/IComparableExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.IComparable.Tests.Unit/IComparableExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("2012/1/1", false)]
         public void IsBetween_when_called_on_date_times_returns_expected_result(string value, bool expectedValue)
         {
-            var testValue = DateTime.Parse(value, CultureInfo.InvariantCulture);
+            var testValue = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
             Assert.Equal(expectedValue, testValue.IsBetween(new DateTime(2011, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2011, 12, 31, 23, 59, 59, DateTimeKind.Utc)));
         }
 
@@ -39,7 +39,8 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("2018/11/6", false)]
         public void IsBetween_when_called_on_specific_dates_returns_expected_result(DateTime value, bool expectedValue)
         {
-            Assert.Equal(expectedValue, value.IsBetween(new DateTime(2018, 11, 2, 0, 0, 0, DateTimeKind.Utc), new DateTime(2018, 11, 6, 0, 0, 0, DateTimeKind.Utc)));
+            var utcValue = DateTime.SpecifyKind(value, DateTimeKind.Utc);
+            Assert.Equal(expectedValue, utcValue.IsBetween(new DateTime(2018, 11, 2, 0, 0, 0, DateTimeKind.Utc), new DateTime(2018, 11, 6, 0, 0, 0, DateTimeKind.Utc)));
         }
 
 
@@ -117,7 +118,7 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("2012/1/1", false)]
         public void IsInRange_when_called_on_date_times_returns_expected_result(string value, bool expectedValue)
         {
-            var testValue = DateTime.Parse(value, CultureInfo.InvariantCulture);
+            var testValue = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
             Assert.Equal(expectedValue, testValue.IsInRange(new DateTime(2011, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2011, 12, 31, 23, 59, 59, DateTimeKind.Utc)));
         }
 
@@ -131,7 +132,8 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("2018/11/7", false)]
         public void IsInRange_when_called_on_specific_dates_returns_expected_result(DateTime value, bool expectedValue)
         {
-            Assert.Equal(expectedValue, value.IsInRange(new DateTime(2018, 11, 2, 0, 0, 0, DateTimeKind.Utc), new DateTime(2018, 11, 6, 0, 0, 0, DateTimeKind.Utc)));
+            var utcValue = DateTime.SpecifyKind(value, DateTimeKind.Utc);
+            Assert.Equal(expectedValue, utcValue.IsInRange(new DateTime(2018, 11, 2, 0, 0, 0, DateTimeKind.Utc), new DateTime(2018, 11, 6, 0, 0, 0, DateTimeKind.Utc)));
         }
 
 

--- a/tests/Wolfgang.Extensions.IComparable.Tests.Unit/IComparableExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.IComparable.Tests.Unit/IComparableExtensionsTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Wolfgang.Extensions.IComparable.Tests.Unit;
 
     // ReSharper disable once InconsistentNaming
@@ -25,8 +27,8 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("2012/1/1", false)]
         public void IsBetween_when_called_on_date_times_returns_expected_result(string value, bool expectedValue)
         {
-            var testValue = DateTime.Parse(value);
-            Assert.Equal(expectedValue, testValue.IsBetween(new DateTime(2011, 1, 1), new DateTime(2011, 12, 31, 23, 59, 59)));
+            var testValue = DateTime.Parse(value, CultureInfo.InvariantCulture);
+            Assert.Equal(expectedValue, testValue.IsBetween(new DateTime(2011, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2011, 12, 31, 23, 59, 59, DateTimeKind.Utc)));
         }
 
 
@@ -37,7 +39,7 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("2018/11/6", false)]
         public void IsBetween_when_called_on_specific_dates_returns_expected_result(DateTime value, bool expectedValue)
         {
-            Assert.Equal(expectedValue, value.IsBetween(new DateTime(2018, 11, 2), new DateTime(2018, 11, 6)));
+            Assert.Equal(expectedValue, value.IsBetween(new DateTime(2018, 11, 2, 0, 0, 0, DateTimeKind.Utc), new DateTime(2018, 11, 6, 0, 0, 0, DateTimeKind.Utc)));
         }
 
 
@@ -115,8 +117,8 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("2012/1/1", false)]
         public void IsInRange_when_called_on_date_times_returns_expected_result(string value, bool expectedValue)
         {
-            var testValue = DateTime.Parse(value);
-            Assert.Equal(expectedValue, testValue.IsInRange(new DateTime(2011, 1, 1), new DateTime(2011, 12, 31, 23, 59, 59)));
+            var testValue = DateTime.Parse(value, CultureInfo.InvariantCulture);
+            Assert.Equal(expectedValue, testValue.IsInRange(new DateTime(2011, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2011, 12, 31, 23, 59, 59, DateTimeKind.Utc)));
         }
 
 
@@ -129,7 +131,7 @@ namespace Wolfgang.Extensions.IComparable.Tests.Unit;
         [InlineData("2018/11/7", false)]
         public void IsInRange_when_called_on_specific_dates_returns_expected_result(DateTime value, bool expectedValue)
         {
-            Assert.Equal(expectedValue, value.IsInRange(new DateTime(2018, 11, 2), new DateTime(2018, 11, 6)));
+            Assert.Equal(expectedValue, value.IsInRange(new DateTime(2018, 11, 2, 0, 0, 0, DateTimeKind.Utc), new DateTime(2018, 11, 6, 0, 0, 0, DateTimeKind.Utc)));
         }
 
 


### PR DESCRIPTION
## Summary
Split from #44. Contains the **non-protected** files — CI validates these changes normally.

**New files from repo-template:**
- `.gitattributes` — line ending normalization
- `.gitleaks.toml` — secret scanning allowlist
- `.github/workflows/codeql.yaml` — CodeQL security analysis
- `.github/workflows/build-all-versions.yaml` — versioned DocFX builds

**Source/test improvements:**
- Allman braces on inline `if` statements (`IComparableExtensions.cs`)
- `CultureInfo.InvariantCulture` on `DateTime.Parse` calls
- `DateTimeKind.Utc` on `DateTime` constructors
- Replace empty `Main` in DotNet462 example with real usage

## Test plan
- [x] `dotnet build --configuration Release` → 0 warnings, 0 errors
- [x] 54 tests pass on net462, net8.0, net10.0
- [ ] CI green on all stages
- Pairs with sister PR for protected config files

🤖 Generated with [Claude Code](https://claude.com/claude-code)