### PR TITLE
Fix toc.yml Project website link to point to this repo

### DIFF
--- a/docfx_project/docs/toc.yml
+++ b/docfx_project/docs/toc.yml
@@ -5,4 +5,4 @@
 - name: Getting Started
   href: getting-started.md
 - name: Project website
-  href: https://github.com/Chris-Wolfgang/DbContextBuilder
+  href: https://github.com/Chris-Wolfgang/IComparable-Extensions


### PR DESCRIPTION
## Summary
- The DocFX TOC's "Project website" link in \`docfx_project/docs/toc.yml\` still pointed to \`https://github.com/Chris-Wolfgang/DbContextBuilder\` — a leftover from when the file was copied from a template.
- Updated to point to this repo.

## Test plan
- [x] Single-line URL change, no behavior impact
- [ ] Verify rendered DocFX TOC link works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)