### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/src/Wolfgang.Extensions.IComparable/Wolfgang.Extensions.IComparable.csproj
+++ b/src/Wolfgang.Extensions.IComparable/Wolfgang.Extensions.IComparable.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>14</LangVersion>
 		<Nullable>enable</Nullable>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<Title>$(AssemblyName)</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A collection of extension methods for IComparable and IComparable&lt;T&gt; types</Description>

--- a/tests/Wolfgang.Extensions.IComparable.Tests.Unit/Wolfgang.Extensions.IComparable.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IComparable.Tests.Unit/Wolfgang.Extensions.IComparable.Tests.Unit.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net462;net472;net48;net481;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- Bumps `Wolfgang.Extensions.IComparable` package version from 1.0.0 to 1.1.0.
- Syncs the test project version to 1.1.0.

## Test plan
- [ ] CI builds and tests pass on all target frameworks