### PR TITLE
Add template scripts

### DIFF
--- a/scripts/Setup-GitHubPages.ps1
+++ b/scripts/Setup-GitHubPages.ps1
@@ -1,0 +1,719 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Sets up GitHub Pages with DocFX for automatic documentation publishing on GitHub Release.
+
+.DESCRIPTION
+    This script automates the setup of GitHub Pages for a .NET repository using DocFX.
+    It performs the following tasks:
+    1. Prompts if you want to set up GitHub Pages for documentation
+    2. Reads repository-specific information automatically where possible
+    3. Prompts for any missing information needed for DocFX configuration
+    4. Replaces placeholders in docfx.json and documentation markdown files
+    5. Creates a gh-pages branch if it doesn't already exist
+    6. Configures GitHub Pages settings to serve from the gh-pages branch
+    7. Verifies the DocFX workflow is reachable via workflow_call from release.yaml
+    
+    Run this script locally after creating a new repository from the template.
+
+.PARAMETER Repository
+    The repository in owner/repo format. If not provided, uses the current repository.
+
+.PARAMETER EnablePages
+    If specified, automatically enables GitHub Pages without prompting.
+
+.PARAMETER SkipPrompt
+    If specified, skips the initial prompt asking if you want to set up GitHub Pages.
+
+.EXAMPLE
+    .\Setup-GitHubPages.ps1
+    Sets up GitHub Pages for the current repository with interactive prompts
+
+.EXAMPLE
+    .\Setup-GitHubPages.ps1 -Repository "Chris-Wolfgang/my-repo"
+    Sets up GitHub Pages for a specific repository
+
+.EXAMPLE
+    .\Setup-GitHubPages.ps1 -EnablePages -SkipPrompt
+    Sets up GitHub Pages and automatically enables it without any prompts
+
+.NOTES
+    Requires: 
+    - GitHub CLI (gh) authenticated with sufficient permissions
+    - Git installed and available in PATH
+    Install gh: https://cli.github.com/
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Repository = "Chris-Wolfgang/IComparable-Extensions",
+    
+    [Parameter()]
+    [switch]$EnablePages,
+    
+    [Parameter()]
+    [switch]$SkipPrompt
+)
+
+# Enable strict mode
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Color output functions
+function Write-Success {
+    param([string]$Message)
+    Write-Host "✅ $Message" -ForegroundColor Green
+}
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "ℹ️  $Message" -ForegroundColor Cyan
+}
+
+function Write-Warning-Custom {
+    param([string]$Message)
+    Write-Host "⚠️  $Message" -ForegroundColor Yellow
+}
+
+function Write-Error-Custom {
+    param([string]$Message)
+    Write-Host "❌ $Message" -ForegroundColor Red
+}
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "`n🔧 $Message" -ForegroundColor Magenta
+}
+
+# Helper function to read input with default value
+function Read-Input {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Prompt,
+        
+        [string]$Default = '',
+        
+        [string]$Example = '',
+        
+        [switch]$Required
+    )
+    
+    $displayPrompt = $Prompt
+    if ($Default) {
+        $displayPrompt += " [$Default]"
+    }
+    if ($Example -and $Example -ne $Default) {
+        $displayPrompt += " (e.g., $Example)"
+    }
+    $displayPrompt += ": "
+    
+    do {
+        Write-Host $displayPrompt -NoNewline -ForegroundColor Yellow
+        $input = Read-Host
+        
+        if ([string]::IsNullOrWhiteSpace($input)) {
+            if ($Default) {
+                return $Default
+            }
+            if ($Required) {
+                Write-Warning-Custom "This field is required. Please enter a value."
+                continue
+            }
+            return ''
+        }
+        
+        return $input.Trim()
+    } while ($true)
+}
+
+# Banner
+Write-Host @"
+
+╔═══════════════════════════════════════════════════════════════════╗
+║                                                                   ║
+║        GitHub Pages Setup - DocFX Documentation Publishing        ║
+║                                                                   ║
+╚═══════════════════════════════════════════════════════════════════╝
+
+"@ -ForegroundColor Cyan
+
+# Initial prompt to confirm setup
+if (-not $SkipPrompt) {
+    Write-Host "`n📚 This script will set up GitHub Pages for your repository documentation." -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "The setup process will:" -ForegroundColor Gray
+    Write-Host "  • Configure DocFX documentation files with your project information" -ForegroundColor Gray
+    Write-Host "  • Create a gh-pages branch for hosting documentation" -ForegroundColor Gray
+    Write-Host "  • Enable GitHub Pages in repository settings" -ForegroundColor Gray
+    Write-Host "  • Verify the DocFX workflow configuration" -ForegroundColor Gray
+    Write-Host ""
+    
+    $response = Read-Host "Do you want to set up GitHub Pages for documentation? (y/N)"
+    if ($response -ne 'y' -and $response -ne 'Y') {
+        Write-Info "Setup cancelled. You can run this script again anytime."
+        exit 0
+    }
+    
+    Write-Host ""
+}
+
+# Check if gh CLI is installed
+Write-Step "Checking prerequisites..."
+try {
+    $null = gh --version
+    Write-Success "GitHub CLI (gh) is installed"
+} catch {
+    Write-Error-Custom "GitHub CLI (gh) is not installed or not in PATH."
+    Write-Host "Install from: https://cli.github.com/" -ForegroundColor Yellow
+    exit 1
+}
+
+# Check if git is installed
+try {
+    $null = git --version
+    Write-Success "Git is installed"
+} catch {
+    Write-Error-Custom "Git is not installed or not in PATH."
+    Write-Host "Install from: https://git-scm.com/" -ForegroundColor Yellow
+    exit 1
+}
+
+# Check if we're in a git repository
+try {
+    $null = git rev-parse --git-dir 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error-Custom "Not in a git repository."
+        Write-Host "Please run this script from within a git repository." -ForegroundColor Yellow
+        exit 1
+    }
+    Write-Success "Running in a git repository"
+} catch {
+    Write-Error-Custom "Not in a git repository."
+    Write-Host "Please run this script from within a git repository." -ForegroundColor Yellow
+    exit 1
+}
+
+# Check if authenticated
+try {
+    $null = gh auth status 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error-Custom "Not authenticated with GitHub CLI."
+        Write-Host "Run: gh auth login" -ForegroundColor Yellow
+        exit 1
+    }
+    Write-Success "Authenticated with GitHub CLI"
+} catch {
+    Write-Error-Custom "Failed to check GitHub CLI authentication status."
+    exit 1
+}
+
+# Determine repository
+if ($Repository -eq "Chris-Wolfgang/IComparable-Extensions" -or -not $Repository) {
+    # Placeholders not replaced or no repository specified - auto-detect
+    Write-Info "Detecting current repository..."
+    try {
+        $repoInfo = gh repo view --json nameWithOwner | ConvertFrom-Json
+        $Repository = $repoInfo.nameWithOwner
+        Write-Success "Using repository: $Repository"
+    } catch {
+        if ($Repository -eq "Chris-Wolfgang/IComparable-Extensions") {
+            Write-Error-Custom "Could not detect repository. Please run the setup script (scripts/setup.ps1 or scripts/setup.sh) first to replace placeholders, or specify -Repository parameter."
+        } else {
+            Write-Error-Custom "Could not detect repository. Please run from within a git repository or specify -Repository parameter."
+        }
+        exit 1
+    }
+} else {
+    Write-Success "Using specified repository: $Repository"
+}
+
+Write-Host "`n📚 Setting up GitHub Pages for: $Repository" -ForegroundColor Cyan
+
+# Configure DocFX files
+Write-Step "Configuring DocFX documentation files..."
+
+# Check if docfx.json has placeholders that need to be replaced
+$docfxJsonPath = "docfx_project/docfx.json"
+$needsDocFxConfig = $false
+
+if (Test-Path $docfxJsonPath) {
+    $docfxContent = Get-Content $docfxJsonPath -Raw
+    if ($docfxContent -match '{{[^}]+}}') {
+        $needsDocFxConfig = $true
+        Write-Info "DocFX configuration files contain placeholders that need to be replaced"
+    } else {
+        Write-Success "DocFX configuration files are already configured"
+    }
+} else {
+    Write-Warning-Custom "docfx.json not found at $docfxJsonPath"
+    Write-Info "Skipping DocFX configuration"
+}
+
+if ($needsDocFxConfig) {
+    Write-Host ""
+    Write-Host "📝 Gathering project information for DocFX configuration..." -ForegroundColor Cyan
+    Write-Host ""
+    
+    # Parse repository information
+    $repoOwner = $Repository -split '/' | Select-Object -First 1
+    $repoName = $Repository -split '/' | Select-Object -Last 1
+    $githubRepoUrl = "https://github.com/$Repository"
+    
+    # Try to get repository description from GitHub
+    try {
+        $repoFullInfo = gh repo view --json description,nameWithOwner | ConvertFrom-Json
+        $autoDescription = $repoFullInfo.description
+        if ([string]::IsNullOrWhiteSpace($autoDescription)) {
+            $autoDescription = "A .NET library/application"
+        }
+    } catch {
+        $autoDescription = "A .NET library/application"
+    }
+    
+    # Calculate default documentation URL
+    $defaultDocsUrl = "https://$repoOwner.github.io/$repoName/"
+    
+    # Prompt for project information
+    $projectName = Read-Input `
+        -Prompt "Project Name" `
+        -Default $repoName `
+        -Example $repoName `
+        -Required
+    
+    $projectDescription = Read-Input `
+        -Prompt "Project Description" `
+        -Default $autoDescription `
+        -Example $autoDescription
+    
+    $packageName = Read-Input `
+        -Prompt "NuGet Package Name (if publishing to NuGet)" `
+        -Default $projectName `
+        -Example $projectName
+    
+    $docsUrl = Read-Input `
+        -Prompt "Documentation URL (GitHub Pages)" `
+        -Default $defaultDocsUrl `
+        -Example $defaultDocsUrl
+    
+    # Ensure docsUrl ends with /
+    if (-not $docsUrl.EndsWith('/')) {
+        $docsUrl += '/'
+    }
+    
+    # Summary
+    Write-Host ""
+    Write-Host "Configuration Summary:" -ForegroundColor Cyan
+    Write-Host "  Project Name:        $projectName" -ForegroundColor Gray
+    Write-Host "  Description:         $projectDescription" -ForegroundColor Gray
+    Write-Host "  Package Name:        $packageName" -ForegroundColor Gray
+    Write-Host "  Repository URL:      $githubRepoUrl" -ForegroundColor Gray
+    Write-Host "  Documentation URL:   $docsUrl" -ForegroundColor Gray
+    Write-Host ""
+    
+    $confirm = Read-Host "Proceed with this configuration? (Y/n)"
+    if ($confirm -and $confirm -ne 'Y' -and $confirm -ne 'y') {
+        Write-Warning-Custom "Configuration cancelled."
+        exit 0
+    }
+    
+    # Create replacements hashtable
+    $replacements = @{
+        '{{PROJECT_NAME}}' = $projectName
+        '{{PROJECT_DESCRIPTION}}' = $projectDescription
+        '{{PACKAGE_NAME}}' = $packageName
+        '{{GITHUB_REPO_URL}}' = $githubRepoUrl
+        '{{DOCS_URL}}' = $docsUrl
+    }
+    
+    # Files to update
+    $filesToUpdate = @(
+        'docfx_project/docfx.json',
+        'docfx_project/index.md',
+        'docfx_project/api/index.md',
+        'docfx_project/api/README.md',
+        'docfx_project/docs/toc.yml',
+        'docfx_project/docs/introduction.md',
+        'docfx_project/docs/getting-started.md'
+    )
+    
+    # Replace placeholders in files
+    Write-Host ""
+    Write-Info "Replacing placeholders in DocFX files..."
+    $filesUpdated = 0
+    
+    foreach ($file in $filesToUpdate) {
+        if (Test-Path $file) {
+            $content = Get-Content $file -Raw -ErrorAction SilentlyContinue
+            if ($content) {
+                $originalContent = $content
+                
+                foreach ($placeholder in $replacements.Keys) {
+                    $pattern = [regex]::Escape($placeholder)
+                    $content = [regex]::Replace(
+                        $content,
+                        $pattern,
+                        [System.Text.RegularExpressions.MatchEvaluator]{ param($m) $replacements[$placeholder] }
+                    )
+                }
+                
+                if ($content -ne $originalContent) {
+                    Set-Content -Path $file -Value $content -NoNewline -Encoding UTF8
+                    Write-Success "  Updated: $file"
+                    $filesUpdated++
+                }
+            }
+        }
+    }
+    
+    if ($filesUpdated -gt 0) {
+        Write-Success "Successfully updated $filesUpdated DocFX file(s)"
+    } else {
+        Write-Info "No files needed updating"
+    }
+    
+    Write-Host ""
+}
+
+# Check if gh-pages branch exists
+Write-Step "Checking for gh-pages branch..."
+try {
+    $branches = git ls-remote --heads origin gh-pages 2>&1
+    
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error-Custom "Error checking for gh-pages branch. Git exited with code $LASTEXITCODE.`nOutput:`n$branches"
+        exit 1
+    }
+    
+    $ghPagesBranchExists = -not [string]::IsNullOrWhiteSpace($branches)
+    
+    if ($ghPagesBranchExists) {
+        Write-Success "gh-pages branch already exists"
+    } else {
+        Write-Info "gh-pages branch does not exist yet"
+        
+        # Check for uncommitted changes before creating gh-pages branch
+        $gitStatus = git status --porcelain 2>&1
+        if (-not [string]::IsNullOrWhiteSpace($gitStatus)) {
+            Write-Warning-Custom "You have uncommitted changes in your working directory."
+            Write-Info "Please commit or stash your changes before proceeding."
+            Write-Info "Uncommitted changes:`n$gitStatus"
+            $response = Read-Host "Do you want to continue anyway? This may cause data loss. (y/N)"
+            if ($response -ne 'y' -and $response -ne 'Y') {
+                Write-Info "Aborting gh-pages branch creation."
+                exit 0
+            }
+        }
+        
+        # Store the current branch name before switching
+        $originalBranch = git rev-parse --abbrev-ref HEAD 2>&1
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($originalBranch) -or 
+            $originalBranch -match '(fatal|error|warning|usage:)') {
+            Write-Warning-Custom "Could not determine current branch name. Will attempt to return to 'main' after creating gh-pages."
+            $originalBranch = "main"  # Default fallback
+        }
+        
+        # Create gh-pages branch
+        Write-Step "Creating gh-pages branch..."
+        
+        # Create an orphan branch (no history)
+        $checkoutOutput = git checkout --orphan gh-pages 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error-Custom "Failed to create orphan gh-pages branch. Git output:`n$checkoutOutput"
+            throw "Git checkout --orphan failed"
+        }
+        
+        # Remove all files from staging
+        $rmOutput = git rm -rf . 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error-Custom "Failed to remove files from staging. Git output:`n$rmOutput"
+            throw "Git rm failed"
+        }
+        
+        # Create a placeholder index.html
+        $placeholderHtml = @"
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Documentation</title>
+</head>
+<body>
+    <h1>Documentation Coming Soon</h1>
+    <p>This site will contain the project documentation once it is generated.</p>
+    <p>Documentation is automatically published when you publish a GitHub Release.</p>
+</body>
+</html>
+"@
+        Set-Content -Path "index.html" -Value $placeholderHtml -Encoding UTF8
+        
+        # Commit and push
+        $addOutput = git add index.html 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error-Custom "Failed to stage index.html. Git output:`n$addOutput"
+            throw "Git add failed"
+        }
+        
+        $commitOutput = git commit -m "Initialize gh-pages branch" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error-Custom "Failed to commit gh-pages branch. Git output:`n$commitOutput"
+            throw "Git commit failed"
+        }
+        
+        $pushOutput = git push origin gh-pages 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error-Custom "Failed to push gh-pages branch. Git output:`n$pushOutput"
+            throw "Git push failed"
+        }
+        
+        # Switch back to original branch
+        try {
+            $checkoutBackOutput = git checkout $originalBranch 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning-Custom "Failed to switch back to original branch '$originalBranch'. Git output:`n$checkoutBackOutput"
+                # Try to detect the default branch as fallback
+                $defaultBranchOutput = git symbolic-ref refs/remotes/origin/HEAD 2>&1
+                if ($LASTEXITCODE -eq 0 -and $defaultBranchOutput -and 
+                    $defaultBranchOutput -notmatch '(fatal|error|warning|usage:)') {
+                    $defaultBranch = $defaultBranchOutput | ForEach-Object { $_ -replace '^refs/remotes/origin/', '' }
+                    $checkoutDefaultOutput = git checkout $defaultBranch 2>&1
+                    if ($LASTEXITCODE -ne 0) {
+                        Write-Warning-Custom "Failed to checkout default branch '$defaultBranch'. Git output:`n$checkoutDefaultOutput"
+                    }
+                } else {
+                    # Try main then master as last resort
+                    $checkoutMainOutput = git checkout main 2>&1
+                    if ($LASTEXITCODE -ne 0) {
+                        $checkoutMasterOutput = git checkout master 2>&1
+                        if ($LASTEXITCODE -ne 0) {
+                            Write-Warning-Custom "Could not switch back to any default branch. You may need to manually switch branches."
+                        }
+                    }
+                }
+            }
+        } catch {
+            Write-Warning-Custom "Could not switch back to original branch. You may need to manually switch branches."
+        }
+        
+        Write-Success "Created and pushed gh-pages branch"
+    }
+} catch {
+    Write-Error-Custom "Failed to check or create gh-pages branch: $_"
+    Write-Host "You may need to create the gh-pages branch manually." -ForegroundColor Yellow
+}
+
+# Check and enable GitHub Pages
+Write-Step "Configuring GitHub Pages settings..."
+try {
+    # Get current Pages configuration
+    $pagesInfo = gh api "/repos/$Repository/pages" 2>&1
+    
+    if ($LASTEXITCODE -eq 0) {
+        $pagesConfig = $pagesInfo | ConvertFrom-Json
+        Write-Success "GitHub Pages is already enabled"
+        Write-Info "   Source: $($pagesConfig.source.branch)/$($pagesConfig.source.path)"
+        if ($pagesConfig.html_url) {
+            Write-Info "   URL: $($pagesConfig.html_url)"
+        }
+        
+        # Check if it's configured to use gh-pages branch
+        if ($pagesConfig.source.branch -ne "gh-pages") {
+            Write-Warning-Custom "GitHub Pages is not configured to use the gh-pages branch"
+            if (-not $EnablePages) {
+                $response = Read-Host "Would you like to update it to use gh-pages branch? (y/N)"
+                if ($response -ne 'y' -and $response -ne 'Y') {
+                    Write-Info "Skipping GitHub Pages branch update"
+                } else {
+                    $EnablePages = $true
+                }
+            }
+            
+            if ($EnablePages) {
+                # Update Pages to use gh-pages branch
+                $pagesConfigUpdate = @{
+                    source = @{
+                        branch = "gh-pages"
+                        path = "/"
+                    }
+                } | ConvertTo-Json
+                
+                $tempFile = [System.IO.Path]::GetTempFileName()
+                $pagesConfigUpdate | Out-File -FilePath $tempFile -Encoding utf8NoBOM
+                
+                try {
+                    $updateOutput = gh api --method PUT "/repos/$Repository/pages" --input $tempFile 2>&1
+                    if ($LASTEXITCODE -ne 0) {
+                        Write-Error-Custom "Failed to update GitHub Pages configuration. GitHub CLI output:`n$updateOutput"
+                    } else {
+                        Write-Success "Updated GitHub Pages to use gh-pages branch"
+                    }
+                } catch {
+                    Write-Error-Custom "Failed to update GitHub Pages configuration: $_"
+                } finally {
+                    if (Test-Path $tempFile) {
+                        Remove-Item $tempFile -Force
+                    }
+                }
+            }
+        }
+    } else {
+        # Pages not enabled, try to enable it
+        Write-Info "GitHub Pages is not enabled yet"
+        
+        if (-not $EnablePages) {
+            $response = Read-Host "Would you like to enable GitHub Pages now? (y/N)"
+            if ($response -ne 'y' -and $response -ne 'Y') {
+                Write-Info "Skipping GitHub Pages setup"
+                Write-Info "You can enable it later in: Settings → Pages"
+            } else {
+                $EnablePages = $true
+            }
+        }
+        
+        if ($EnablePages) {
+            # Enable Pages with gh-pages branch
+            $pagesConfig = @{
+                source = @{
+                    branch = "gh-pages"
+                    path = "/"
+                }
+            } | ConvertTo-Json
+            
+            $tempFile = [System.IO.Path]::GetTempFileName()
+            $pagesConfig | Out-File -FilePath $tempFile -Encoding utf8NoBOM
+            
+            try {
+                $enableOutput = gh api --method POST "/repos/$Repository/pages" --input $tempFile 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Error-Custom "Failed to enable GitHub Pages. GitHub CLI output:`n$enableOutput"
+                    Write-Host "You may need to enable it manually in: Settings → Pages" -ForegroundColor Yellow
+                } else {
+                    Write-Success "Enabled GitHub Pages with gh-pages branch"
+                    
+                    # Get the Pages URL
+                    Start-Sleep -Seconds 2
+                    $pagesUrlInfo = gh api "/repos/$Repository/pages" 2>&1
+                    if ($LASTEXITCODE -eq 0) {
+                        $pagesUrlData = $pagesUrlInfo | ConvertFrom-Json
+                        if ($pagesUrlData.html_url) {
+                            Write-Info "   URL: $($pagesUrlData.html_url)"
+                        }
+                    }
+                }
+            } catch {
+                Write-Error-Custom "Failed to enable GitHub Pages: $_"
+                Write-Host "You may need to enable it manually in: Settings → Pages" -ForegroundColor Yellow
+            } finally {
+                if (Test-Path $tempFile) {
+                    Remove-Item $tempFile -Force
+                }
+            }
+        }
+    }
+} catch {
+    Write-Warning-Custom "Could not check GitHub Pages configuration"
+    Write-Info "You may need to enable GitHub Pages manually in: Settings → Pages"
+}
+
+# Verify DocFX workflow configuration
+Write-Step "Verifying DocFX workflow configuration..."
+$workflowPath = ".github/workflows/docfx.yaml"
+
+if (Test-Path $workflowPath) {
+    $workflowContent = Get-Content $workflowPath -Raw
+    $normalizedWorkflowContent = $workflowContent -replace "`r`n", "`n"
+    
+    # Check if workflow is triggered via workflow_call (called by release.yaml)
+    $hasWorkflowCall = $normalizedWorkflowContent -match 'workflow_call:'
+    
+    if ($hasWorkflowCall) {
+        Write-Success "DocFX workflow is configured to be called via workflow_call from release.yaml"
+    } else {
+        Write-Warning-Custom "DocFX workflow does not appear to be configured for workflow_call"
+        Write-Info "The DocFX workflow should be invoked by release.yaml via workflow_call"
+        Write-Info "   after a GitHub Release is published."
+        Write-Info ""
+        Write-Info "To enable automatic documentation publishing on GitHub Release:"
+        Write-Info "   1. Edit $workflowPath"
+        Write-Info "   2. Ensure the 'on:' section includes:"
+        Write-Info ""
+        Write-Host @"
+      on:
+        workflow_call:
+          inputs:
+            version:
+              description: 'Version tag for documentation (e.g., v1.0.0).'
+              required: false
+              default: ''
+              type: string
+        workflow_dispatch:
+"@ -ForegroundColor DarkGray
+        Write-Info ""
+        Write-Info "   3. In release.yaml, add a job that calls docfx.yaml:"
+        Write-Info ""
+        Write-Host @"
+      trigger-docs:
+        needs: validate-release
+        permissions:
+          contents: write
+        uses: ./.github/workflows/docfx.yaml
+        with:
+          version: `${{ github.event.release.tag_name }}
+"@ -ForegroundColor DarkGray
+        Write-Info ""
+    }
+} else {
+    Write-Warning-Custom "DocFX workflow not found at $workflowPath"
+    Write-Info "Ensure you have a DocFX workflow configured"
+}
+
+# Summary
+Write-Host "`n" + ("=" * 70) -ForegroundColor Cyan
+Write-Host "📋 Setup Summary" -ForegroundColor Cyan
+Write-Host ("=" * 70) -ForegroundColor Cyan
+
+Write-Host "`n✅ Completed Tasks:" -ForegroundColor Green
+if ($needsDocFxConfig -and $filesUpdated -gt 0) {
+    Write-Host "   • Configured DocFX files with project information" -ForegroundColor Gray
+}
+Write-Host "   • Verified/Created gh-pages branch" -ForegroundColor Gray
+if ($EnablePages) {
+    Write-Host "   • Configured GitHub Pages settings" -ForegroundColor Gray
+}
+Write-Host "   • Verified DocFX workflow configuration" -ForegroundColor Gray
+
+Write-Host "`n📝 Next Steps:" -ForegroundColor Yellow
+if ($needsDocFxConfig -and $filesUpdated -gt 0) {
+    Write-Host "   1. Review and customize the generated documentation in docfx_project/" -ForegroundColor Gray
+    Write-Host "   2. Publish a GitHub Release to trigger documentation deployment" -ForegroundColor Gray
+    Write-Host "   3. Check the Actions tab to see the documentation build" -ForegroundColor Gray
+    Write-Host "   4. Visit your documentation site once published" -ForegroundColor Gray
+} else {
+    Write-Host "   1. Ensure docfx_project/docfx.json is configured for your project" -ForegroundColor Gray
+    Write-Host "   2. Ensure .github/workflows/docfx.yaml has workflow_call in its 'on:' triggers and is called by release.yaml" -ForegroundColor Gray
+    Write-Host "   3. Publish a GitHub Release to trigger documentation deployment" -ForegroundColor Gray
+    Write-Host "   4. Check the Actions tab to see the documentation build" -ForegroundColor Gray
+}
+
+Write-Host "`n🔗 Useful Links:" -ForegroundColor Cyan
+Write-Host "   • Repository: https://github.com/$Repository" -ForegroundColor Blue
+Write-Host "   • Actions: https://github.com/$Repository/actions" -ForegroundColor Blue
+Write-Host "   • Settings → Pages: https://github.com/$Repository/settings/pages" -ForegroundColor Blue
+
+# Get Pages URL if available
+try {
+    $pagesUrlOutput = gh api "/repos/$Repository/pages" 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $pagesUrlInfo = $pagesUrlOutput | ConvertFrom-Json
+        if ($pagesUrlInfo.html_url) {
+            Write-Host "   • Documentation: $($pagesUrlInfo.html_url)" -ForegroundColor Blue
+        }
+    }
+} catch {
+    # Silently ignore if we can't get the URL
+}
+
+Write-Host "`n🎉 GitHub Pages setup complete!" -ForegroundColor Green
+Write-Host ""

--- a/scripts/Setup-Labels.ps1
+++ b/scripts/Setup-Labels.ps1
@@ -1,0 +1,116 @@
+<#
+.SYNOPSIS
+    Creates custom GitHub labels for the repository.
+
+.DESCRIPTION
+    This script uses the GitHub CLI (gh) to create labels used by Dependabot and
+    other workflows. Run this locally once after creating a new repo from the template.
+    
+    Labels created:
+    - dependabot - security  (red)
+    - dependabot-dependencies (orange)
+    - dependencies           (blue)
+    - dotnet                 (purple)
+
+.PARAMETER Repository
+    The repository in owner/repo format. If not provided, uses the current repository.
+
+.EXAMPLE
+    .\Setup-Labels.ps1
+    Creates the labels for the current repository
+
+.EXAMPLE
+    .\Setup-Labels.ps1 -Repository "Chris-Wolfgang/my-repo"
+    Creates the labels for a specific repository
+
+.NOTES
+    Requires: GitHub CLI (gh) authenticated with sufficient permissions
+    Install gh: https://cli.github.com/
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Repository
+)
+
+# Check if gh CLI is installed
+try {
+    $null = gh --version
+} catch {
+    Write-Error "❌ GitHub CLI (gh) is not installed or not in PATH."
+    Write-Host "Install from: https://cli.github.com/" -ForegroundColor Yellow
+    exit 1
+}
+
+# Check if authenticated
+try {
+    $null = gh auth status 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "❌ Not authenticated with GitHub CLI."
+        Write-Host "Run: gh auth login" -ForegroundColor Yellow
+        exit 1
+    }
+} catch {
+    Write-Error "❌ Failed to check GitHub CLI authentication status."
+    exit 1
+}
+
+# Determine repository
+if (-not $Repository) {
+    Write-Host "🔍 Detecting current repository..." -ForegroundColor Cyan
+    try {
+        $repoInfo = gh repo view --json nameWithOwner | ConvertFrom-Json
+        $Repository = $repoInfo.nameWithOwner
+        Write-Host "✅ Using repository: $Repository" -ForegroundColor Green
+    } catch {
+        Write-Error "❌ Could not detect repository. Please run from within a git repository or specify -Repository parameter."
+        exit 1
+    }
+} else {
+    Write-Host "✅ Using specified repository: $Repository" -ForegroundColor Green
+}
+
+Write-Host "`n🏷️  Creating labels for: $Repository`n" -ForegroundColor Cyan
+
+$labels = @(
+    @{ name = "dependabot - security";    color = "b60205"; description = "Security update from Dependabot" },
+    @{ name = "dependabot-dependencies";  color = "d93f0b"; description = "Dependency update from Dependabot" },
+    @{ name = "dependencies";             color = "0366d6"; description = "Pull requests that update a dependency file" },
+    @{ name = "dotnet";                   color = "512bd4"; description = ".NET related changes" }
+)
+
+$created = 0
+$skipped = 0
+$failed  = 0
+
+foreach ($label in $labels) {
+    $response = gh api `
+        --method POST `
+        -H "Accept: application/vnd.github+json" `
+        -H "X-GitHub-Api-Version: 2022-11-28" `
+        "/repos/$Repository/labels" `
+        -f "name=$($label.name)" `
+        -f "color=$($label.color)" `
+        -f "description=$($label.description)" 2>&1
+
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "   ✅ Created label: $($label.name)" -ForegroundColor Green
+        $created++
+    } elseif ($response -like "*already_exists*") {
+        Write-Host "   ⏭️  Label already exists, skipping: $($label.name)" -ForegroundColor Gray
+        $skipped++
+    } else {
+        Write-Host "   ❌ Failed to create label: $($label.name)" -ForegroundColor Red
+        Write-Host "      $response" -ForegroundColor Red
+        $failed++
+    }
+}
+
+Write-Host ""
+if ($failed -eq 0) {
+    Write-Host "🎉 Done! Created: $created, Skipped (already existed): $skipped" -ForegroundColor Green
+} else {
+    Write-Host "⚠️  Done with errors. Created: $created, Skipped: $skipped, Failed: $failed" -ForegroundColor Yellow
+    exit 1
+}

--- a/scripts/format.ps1
+++ b/scripts/format.ps1
@@ -1,0 +1,104 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Formats all C# code in the repository using dotnet format.
+
+.DESCRIPTION
+    This script runs 'dotnet format' on the solution to ensure consistent code formatting.
+    Run this before committing to ensure your code passes the formatting checks in CI.
+
+.PARAMETER Check
+    If specified, only checks formatting without making changes (like CI does).
+
+.EXAMPLE
+    .\format.ps1
+    Formats all code in the repository.
+
+.EXAMPLE
+    .\format.ps1 -Check
+    Checks formatting without making changes.
+#>
+
+param(
+    [switch]$Check
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "🎨 Code Formatting Script" -ForegroundColor Cyan
+Write-Host ""
+
+# Verify dotnet format is available (built into .NET 6+ SDK)
+Write-Host "🔍 Checking for dotnet format..." -ForegroundColor Yellow
+dotnet format --version | Out-Null
+
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Host ""
+    Write-Host "❌ dotnet format is not available!" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "The 'dotnet format' command is built into the .NET SDK starting with .NET 6." -ForegroundColor Yellow
+    Write-Host "This project requires .NET 8.0 SDK or later." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "Please install the .NET 8.0 SDK or later from:" -ForegroundColor Yellow
+    Write-Host "https://dotnet.microsoft.com/download" -ForegroundColor Cyan
+    Write-Host ""
+    exit 1
+}
+
+Write-Host "✅ dotnet format is available" -ForegroundColor Green
+Write-Host ""
+
+# Find solution file
+$solution = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq '.sln' -or $_.Extension -eq '.slnx' } | Select-Object -First 1
+
+if (-not $solution)
+{
+    Write-Host "❌ No solution file found!" -ForegroundColor Red
+    exit 1
+}
+
+$solutionFile = $solution.FullName
+Write-Host "📁 Found solution: $($solution.Name)" -ForegroundColor Green
+Write-Host ""
+
+if ($Check)
+{
+    Write-Host "🔍 Checking code formatting (read-only mode)..." -ForegroundColor Yellow
+    Write-Host ""
+    
+    dotnet format $solutionFile --verify-no-changes --verbosity diagnostic
+    
+    if ($LASTEXITCODE -eq 0)
+    {
+        Write-Host ""
+        Write-Host "✅ All files are properly formatted!" -ForegroundColor Green
+    }
+    else
+    {
+        Write-Host ""
+        Write-Host "❌ Formatting issues detected!" -ForegroundColor Red
+        Write-Host "Run '.\format.ps1' (without -Check) to fix them automatically." -ForegroundColor Yellow
+        exit 1
+    }
+}
+else
+{
+    Write-Host "✏️  Formatting code..." -ForegroundColor Yellow
+    Write-Host ""
+    
+    dotnet format $solutionFile --verbosity diagnostic
+    
+    if ($LASTEXITCODE -eq 0)
+    {
+        Write-Host ""
+        Write-Host "✅ Code formatting complete!" -ForegroundColor Green
+        Write-Host "Review changes and commit them." -ForegroundColor Cyan
+    }
+    else
+    {
+        Write-Host ""
+        Write-Host "❌ Formatting failed!" -ForegroundColor Red
+        exit 1
+    }
+}

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,1042 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Automated setup script for .NET repository template
+.DESCRIPTION
+    This script automates the process of configuring a new repository created from this template.
+    It prompts for project information, replaces placeholders, sets up the license, and validates changes.
+    
+    The script automatically ensures it runs from the repository root directory:
+    - If run from the scripts/ directory, it will automatically change to the repository root
+    - If run from any other location, it will display an error and exit
+    
+.EXAMPLE
+    # Recommended: Run from repository root
+    pwsh ./scripts/setup.ps1
+    
+.EXAMPLE
+    # Also works: Run from scripts directory (auto-corrects to root)
+    cd scripts
+    pwsh ./setup.ps1
+    
+.NOTES
+    Requires PowerShell Core 7.0 or later (cross-platform)
+#>
+
+[CmdletBinding()]
+param()
+
+# Enable strict mode
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Color output functions
+function Write-Success {
+    param([string]$Message)
+    Write-Host "✅ $Message" -ForegroundColor Green
+}
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "ℹ️  $Message" -ForegroundColor Cyan
+}
+
+function Write-TemplateWarning {
+    param([string]$Message)
+    Write-Host "⚠️  $Message" -ForegroundColor Yellow
+}
+
+function Write-TemplateError {
+    param([string]$Message)
+    Write-Host "❌ $Message" -ForegroundColor Red
+}
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "`n🔧 $Message" -ForegroundColor Magenta
+}
+
+# Banner
+function Show-Banner {
+    Write-Host @"
+
+╔════════════════════════════════════════════════════════════════╗
+║                                                                ║
+║        .NET Repository Template - Automated Setup              ║
+║                                                                ║
+╚════════════════════════════════════════════════════════════════╝
+
+"@ -ForegroundColor Cyan
+}
+
+# Ensure script is running from repository root
+function Set-RepositoryRoot {
+    # Get the directory where the script is located
+    $scriptDir = Split-Path -Parent $PSCommandPath
+    
+    # If we're in the scripts directory, move up one level to the repository root
+    if ((Split-Path -Leaf $scriptDir) -eq 'scripts') {
+        $repoRoot = Split-Path -Parent $scriptDir
+        Set-Location $repoRoot
+        Write-Info "Changed working directory to repository root: $repoRoot"
+    }
+    
+    # Verify we're in the repository root by checking for key marker files
+    $markerFiles = @('README.md', '.gitignore', 'CONTRIBUTING.md')
+    $foundMarkers = @($markerFiles | Where-Object { Test-Path $_ })
+    
+    if ($foundMarkers.Count -lt 2) {
+        Write-TemplateError "This script must be run from the repository root directory."
+        Write-Host "Expected to find key files like: $($markerFiles -join ', ')" -ForegroundColor Red
+        Write-Host "Current directory: $(Get-Location)" -ForegroundColor Yellow
+        Write-Host ""
+        Write-Host "Please run the script from the repository root:" -ForegroundColor Yellow
+        Write-Host "  pwsh ./scripts/setup.ps1" -ForegroundColor Cyan
+        throw "Script not running from repository root"
+    }
+}
+
+# Auto-detect git information
+function Get-GitInfo {
+    $gitInfo = @{
+        RemoteUrl = ''
+        RepoName = ''
+        Username = ''
+        UserEmail = ''
+        FullName = ''
+    }
+    
+    try {
+        # Get remote URL
+        $remoteUrl = git remote get-url origin 2>$null
+        if ($remoteUrl) {
+            $gitInfo.RemoteUrl = $remoteUrl -replace '\.git$', ''
+            
+            # Extract repo name
+            if ($remoteUrl -match '/([^/]+?)(?:\.git)?$') {
+                $gitInfo.RepoName = $matches[1]
+            }
+            
+            # Extract username (for GitHub URLs)
+            if ($remoteUrl -match 'github\.com[:/]([^/]+)/') {
+                $gitInfo.Username = "@$($matches[1])"
+            }
+        }
+        
+        # Get git user name
+        $userName = git config user.name 2>$null
+        if ($userName) {
+            $gitInfo.FullName = $userName
+        }
+        
+        # Get git user email
+        $userEmail = git config user.email 2>$null
+        if ($userEmail) {
+            $gitInfo.UserEmail = $userEmail
+        }
+    }
+    catch {
+        Write-Warning "Could not auto-detect git information"
+    }
+    
+    return $gitInfo
+}
+
+# Prompt for input with default and example
+function Read-Input {
+    param(
+        [string]$Prompt,
+        [string]$Default = '',
+        [string]$Example = '',
+        [switch]$Required
+    )
+    
+    $message = $Prompt
+    if ($Example) {
+        $message += "`n   Example: $Example"
+    }
+    if ($Default) {
+        $message += "`n   Default: $Default"
+    }
+    $message += "`n   > "
+    
+    do {
+        Write-Host $message -NoNewline -ForegroundColor Yellow
+        $userInput = Read-Host
+        
+        if ([string]::IsNullOrWhiteSpace($userInput) -and $Default) {
+            return $Default
+        }
+        
+        if ([string]::IsNullOrWhiteSpace($userInput) -and $Required) {
+            Write-TemplateError "This field is required. Please enter a value."
+            continue
+        }
+        
+        return $userInput
+    } while ($true)
+}
+
+# Replace placeholders in a file
+function Replace-Placeholders {
+    param(
+        [string]$FilePath,
+        [hashtable]$Replacements
+    )
+    
+    if (-not (Test-Path $FilePath)) {
+        Write-Warning "File not found: $FilePath"
+        return
+    }
+    
+    $content = Get-Content $FilePath -Raw
+    $modified = $false
+    
+    foreach ($key in $Replacements.Keys) {
+        $placeholder = "{{$key}}"
+        if ($content -match [regex]::Escape($placeholder)) {
+            $pattern = [regex]::Escape($placeholder)
+            $content = [regex]::Replace(
+                $content,
+                $pattern,
+                [System.Text.RegularExpressions.MatchEvaluator]{ param($m) $Replacements[$key] }
+            )
+            $modified = $true
+        }
+    }
+    
+    if ($modified) {
+        Set-Content -Path $FilePath -Value $content
+        Write-Success "Updated: $FilePath"
+    }
+}
+
+# Main setup function
+function Start-Setup {
+    Show-Banner
+    
+    # Ensure we're in the repository root
+    Set-RepositoryRoot
+    
+    Write-Info "This script will configure your new repository."
+    Write-Info "It will prompt you for project information and replace all placeholders."
+    Write-Host ""
+    
+    # Auto-detect git info
+    Write-Step "Auto-detecting git repository information..."
+    $gitInfo = Get-GitInfo
+    
+    if ($gitInfo.RemoteUrl) {
+        Write-Success "Detected repository: $($gitInfo.RemoteUrl)"
+    }
+    
+    # Collect project information
+    Write-Step "Collecting project information..."
+    Write-Host ""
+    
+    # Ask if creating NuGet package
+    Write-Host "Will this project be published as a NuGet package? (Y/n): " -NoNewline -ForegroundColor Yellow
+    $createNugetPackage = Read-Host
+    if ([string]::IsNullOrEmpty($createNugetPackage) -or $createNugetPackage -eq 'Y' -or $createNugetPackage -eq 'y') {
+        $isNugetPackage = $true
+    }
+    else {
+        $isNugetPackage = $false
+    }
+    Write-Host ""
+    
+    $projectName = Read-Input `
+        -Prompt "Project Name (e.g., Wolfgang.Extensions.IAsyncEnumerable)" `
+        -Example "MyCompany.MyLibrary" `
+        -Required
+    
+    $projectDescription = Read-Input `
+        -Prompt "Project Description (one-line description)" `
+        -Example "High-performance extension methods for IAsyncEnumerable<T>" `
+        -Required
+    
+    if ($isNugetPackage) {
+        $packageName = Read-Input `
+            -Prompt "NuGet Package Name" `
+            -Default $projectName `
+            -Example $projectName
+    }
+    else {
+        $packageName = $projectName
+    }
+    
+    $githubRepoUrl = Read-Input `
+        -Prompt "GitHub Repository URL" `
+        -Default $gitInfo.RemoteUrl `
+        -Example "https://github.com/username/repo-name" `
+        -Required
+    
+    # Extract repo name from URL if not already detected
+    $repoName = $gitInfo.RepoName
+    if ([string]::IsNullOrWhiteSpace($repoName) -and $githubRepoUrl -match '/([^/]+?)(?:\.git)?$') {
+        $repoName = $matches[1]
+    }
+    if ([string]::IsNullOrWhiteSpace($repoName)) {
+        $repoName = Read-Input `
+            -Prompt "Repository Name" `
+            -Example "my-repo-name" `
+            -Required
+    }
+    
+    $githubUsername = Read-Input `
+        -Prompt "GitHub Username (with @)" `
+        -Default $gitInfo.Username `
+        -Example "@YourUsername" `
+        -Required
+    
+    # Ensure @ prefix
+    if ($githubUsername -notmatch '^@') {
+        $githubUsername = "@$githubUsername"
+    }
+    
+    # Normalize GitHub URL and generate docs URL
+    # Handle SSH URLs (git@github.com:org/repo.git) and HTTPS URLs
+    # Remove trailing .git and normalize to https://github.com/<owner>/<repo>
+    $normalizedUrl = $githubRepoUrl
+    
+    # Convert SSH URL to HTTPS format
+    if ($normalizedUrl -match '^git@github\.com:(.+)$') {
+        $normalizedUrl = "https://github.com/$($matches[1])"
+    }
+    
+    # Remove trailing .git
+    $normalizedUrl = $normalizedUrl -replace '\.git$', ''
+    
+    # Extract owner and repo from normalized HTTPS URL
+    $docsUrl = $normalizedUrl -replace 'https://github\.com/([^/]+)/([^/]+).*', 'https://$1.github.io/$2/'
+    
+    $docsUrl = Read-Input `
+        -Prompt "Documentation URL (GitHub Pages)" `
+        -Default $docsUrl `
+        -Example "https://username.github.io/repo-name/"
+    
+    # Get copyright holder
+    $copyrightHolder = Read-Input `
+        -Prompt "Copyright Holder Name" `
+        -Default $gitInfo.FullName `
+        -Example "John Doe" `
+        -Required
+    
+    $currentYear = (Get-Date).Year
+    $year = Read-Input `
+        -Prompt "Copyright Year" `
+        -Default $currentYear.ToString() `
+        -Example $currentYear.ToString()
+    
+    if ($isNugetPackage) {
+        $nugetStatus = Read-Input `
+            -Prompt "NuGet Package Status" `
+            -Default "Coming soon to NuGet.org" `
+            -Example "Available on NuGet.org"
+    }
+    else {
+        $nugetStatus = "Not applicable"
+    }
+    
+    # License selection
+    Write-Step "Selecting License..."
+    Write-Host ""
+    Write-Host "Available licenses:" -ForegroundColor Yellow
+    Write-Host "  1) MIT - Most permissive, simple, business-friendly"
+    Write-Host "  2) Apache-2.0 - Permissive with patent grant"
+    Write-Host "  3) MPL-2.0 - Weak copyleft, file-level"
+    Write-Host ""
+    Write-Host "For detailed comparison, see LICENSE-SELECTION.md" -ForegroundColor Cyan
+    Write-Host ""
+    
+    do {
+        Write-Host "Select license (1-3): " -NoNewline -ForegroundColor Yellow
+        $licenseChoice = Read-Host
+        
+        switch ($licenseChoice) {
+            '1' { 
+                $licenseType = 'MIT'
+                $licenseFile = 'LICENSE-MIT.txt'
+                break
+            }
+            '2' { 
+                $licenseType = 'Apache-2.0'
+                $licenseFile = 'LICENSE-APACHE-2.0.txt'
+                break
+            }
+            '3' { 
+                $licenseType = 'MPL-2.0'
+                $licenseFile = 'LICENSE-MPL-2.0.txt'
+                break
+            }
+            default {
+                Write-TemplateError "Invalid choice. Please enter 1, 2, or 3."
+                continue
+            }
+        }
+        break
+    } while ($true)
+    
+    Write-Success "Selected: $licenseType License"
+    
+    # Template repository info (for REPO-INSTRUCTIONS.md)
+    $templateRepoOwner = Read-Input `
+        -Prompt "Template Repository Owner (the GitHub user/org that owns the template you used)" `
+        -Default "Chris-Wolfgang" `
+        -Example "YourUsername"
+    
+    $templateRepoName = Read-Input `
+        -Prompt "Template Repository Name (the name of the template repository you used)" `
+        -Default "repo-template" `
+        -Example "my-template"
+    
+    # Solution creation
+    Write-Step "Solution Creation"
+    Write-Host ""
+    Write-Host "Create a default solution? (y/N): " -NoNewline -ForegroundColor Yellow
+    $createSolution = Read-Host
+    
+    $solutionName = ''
+    if ($createSolution -eq 'y' -or $createSolution -eq 'Y') {
+        $isValidSolutionName = $false
+        while (-not $isValidSolutionName) {
+            $solutionName = Read-Input `
+                -Prompt "Solution Name" `
+                -Default $repoName `
+                -Example $repoName `
+                -Required
+
+            $invalidFileNameChars = [System.IO.Path]::GetInvalidFileNameChars()
+            if ($solutionName.IndexOfAny($invalidFileNameChars) -ne -1) {
+                $invalidCharsDisplay = -join $invalidFileNameChars
+                Write-Error "Solution name contains invalid characters. Please avoid any of: $invalidCharsDisplay" -ErrorAction Continue
+            }
+            else {
+                $isValidSolutionName = $true
+            }
+        }
+    }
+    
+    # Summary
+    Write-Step "Configuration Summary"
+    Write-Host ""
+    Write-Host "Project Information:" -ForegroundColor Cyan
+    Write-Host "  Project Name:        $projectName"
+    Write-Host "  Description:         $projectDescription"
+    Write-Host "  Package Name:        $packageName"
+    Write-Host "  Repository URL:      $githubRepoUrl"
+    Write-Host "  Repository Name:     $repoName"
+    Write-Host "  GitHub Username:     $githubUsername"
+    Write-Host "  Documentation URL:   $docsUrl"
+    Write-Host "  License:             $licenseType"
+    Write-Host "  Copyright Holder:    $copyrightHolder"
+    Write-Host "  Copyright Year:      $year"
+    Write-Host "  NuGet Status:        $nugetStatus"
+    Write-Host "  Template Owner:      $templateRepoOwner"
+    Write-Host "  Template Name:       $templateRepoName"
+    if ($solutionName) {
+        Write-Host "  Solution Name:       $solutionName"
+    }
+    Write-Host ""
+    
+    Write-Host "Proceed with configuration? (Y/n): " -NoNewline -ForegroundColor Yellow
+    $confirm = Read-Host
+    if ($confirm -and $confirm -ne 'Y' -and $confirm -ne 'y') {
+        Write-Warning "Setup cancelled."
+        exit 0
+    }
+    
+    # Create replacements hashtable
+    $replacements = @{
+        'PROJECT_NAME' = $projectName
+        'PROJECT_DESCRIPTION' = $projectDescription
+        'PACKAGE_NAME' = $packageName
+        'GITHUB_REPO_URL' = $githubRepoUrl
+        'REPO_NAME' = $repoName
+        'GITHUB_USERNAME' = $githubUsername
+        'DOCS_URL' = $docsUrl
+        'LICENSE_TYPE' = $licenseType
+        'YEAR' = $year
+        'COPYRIGHT_HOLDER' = $copyrightHolder
+        'NUGET_STATUS' = $nugetStatus
+        'TEMPLATE_REPO_OWNER' = $templateRepoOwner
+        'TEMPLATE_REPO_NAME' = $templateRepoName
+    }
+    
+    # Perform setup
+    Write-Step "Performing setup..."
+    Write-Host ""
+    
+    $totalSteps = if ($solutionName) { 5 } else { 4 }
+    
+    # Step 1: README swap
+    Write-Info "Step 1/${totalSteps}: Swapping README files..."
+    if (Test-Path 'README.md') {
+        Remove-Item 'README.md' -Force
+        Write-Success "Deleted template README.md"
+    }
+    
+    if (Test-Path 'README-TEMPLATE.md') {
+        Rename-Item 'README-TEMPLATE.md' 'README.md'
+        Write-Success "Renamed README-TEMPLATE.md → README.md"
+    }
+    else {
+        Write-Error "README-TEMPLATE.md not found!"
+        exit 1
+    }
+    
+    # Step 2: Replace placeholders
+    Write-Info "Step 2/${totalSteps}: Replacing placeholders in files..."
+    
+    $filesToUpdate = @(
+        'README.md',
+        'CONTRIBUTING.md',
+        '.github/CODEOWNERS',
+        'REPO-INSTRUCTIONS.md',
+        'scripts/Setup-BranchRuleset.ps1',
+        'docfx_project/docfx.json',
+        'docfx_project/index.md',
+        'docfx_project/api/index.md',
+        'docfx_project/api/README.md',
+        'docfx_project/docs/toc.yml',
+        'docfx_project/docs/introduction.md',
+        'docfx_project/docs/getting-started.md',
+        'BannedSymbols.txt'
+    )
+    
+    foreach ($file in $filesToUpdate) {
+        Replace-Placeholders -FilePath $file -Replacements $replacements
+    }
+    
+    # Step 3: Set up LICENSE
+    Write-Info "Step 3/${totalSteps}: Setting up LICENSE file..."
+    
+    if (Test-Path $licenseFile) {
+        # Read license template
+        $licenseContent = Get-Content $licenseFile -Raw
+        
+        # Replace placeholders using safe regex replacement with MatchEvaluator
+        $licenseContent = [regex]::Replace(
+            $licenseContent,
+            [regex]::Escape('{{YEAR}}'),
+            [System.Text.RegularExpressions.MatchEvaluator]{ param($m) $year }
+        )
+        $licenseContent = [regex]::Replace(
+            $licenseContent,
+            [regex]::Escape('{{COPYRIGHT_HOLDER}}'),
+            [System.Text.RegularExpressions.MatchEvaluator]{ param($m) $copyrightHolder }
+        )
+        
+        # Save as LICENSE
+        Set-Content -Path 'LICENSE' -Value $licenseContent -NoNewline
+        Write-Success "Created LICENSE file ($licenseType)"
+        
+        # Delete all license templates
+        Remove-Item 'LICENSE-MIT.txt' -Force -ErrorAction SilentlyContinue
+        Remove-Item 'LICENSE-APACHE-2.0.txt' -Force -ErrorAction SilentlyContinue
+        Remove-Item 'LICENSE-MPL-2.0.txt' -Force -ErrorAction SilentlyContinue
+        Write-Success "Removed license template files"
+    }
+    else {
+        Write-Error "License template file not found: $licenseFile"
+        exit 1
+    }
+    
+    # Step 4: Create solution (if requested)
+    if ($solutionName) {
+        Write-Info "Step 4/${totalSteps}: Creating solution file..."
+        
+        # Create blank solution in .slnx format
+        # Note: .slnx format requires Visual Studio 2022 version 17.10 or later
+        $solutionFileName = "$solutionName.slnx"
+        
+        # Build the solution XML structure
+        $xmlBuilder = New-Object System.Text.StringBuilder
+        [void]$xmlBuilder.AppendLine('<Solution>')
+        
+        # Build .root folder with all remaining files
+        # Exclude files and directories that have their own solution folders or are build artifacts
+        # Note: .git directory is excluded separately below
+        $excludePatterns = @(
+            'obj',                # Build output
+            'bin',                # Build output
+            'TestResults',        # Test artifacts
+            'CoverageReport',     # Coverage artifacts
+            'node_modules',       # Node dependencies
+            '*.user',             # User-specific files
+            '*.suo',              # Visual Studio user options
+            '*.sln',              # Solution files (prevent including solution in itself)
+            '*.slnx',             # Solution files (prevent including solution in itself)
+            '*.env',              # Environment files (may contain secrets)
+            '*.key',              # Key files (may contain secrets)
+            '*.pem',              # Certificate files (may contain secrets)
+            'secrets*',           # Secret files
+            'benchmarks',         # Has its own solution folder
+            'examples',           # Has its own solution folder
+            'src',                # Has its own solution folder
+            'tests',              # Has its own solution folder
+            'docfx_project'       # Documentation source (built separately)
+        )
+        
+        # Get current directory for relative path calculation
+        $currentDir = Get-Location
+        
+        # Helper function to get relative path safely
+        function Get-SafeRelativePath {
+            param($FullPath)
+            try {
+                # Use Resolve-Path with -Relative for safe relative path calculation
+                $rel = Resolve-Path -Path $FullPath -Relative -ErrorAction Stop
+                # Remove leading .\ or ./ prefix properly
+                if ($rel.StartsWith('.\')) {
+                    $rel = $rel.Substring(2)
+                }
+                elseif ($rel.StartsWith('./')) {
+                    $rel = $rel.Substring(2)
+                }
+                return $rel.Replace('\', '/')
+            }
+            catch {
+                # Fallback: manual calculation
+                $path = $FullPath
+                if ($path.StartsWith($currentDir.Path, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    $baseLength = $currentDir.Path.Length
+                    # Ensure we only strip the base path when it's a complete directory component
+                    if ($path.Length -eq $baseLength -or
+                        ($path.Length -gt $baseLength -and
+                         ($path[$baseLength] -eq [System.IO.Path]::DirectorySeparatorChar -or
+                          $path[$baseLength] -eq [System.IO.Path]::AltDirectorySeparatorChar))) {
+                        # Remove the base path and any leading separator
+                        $path = $path.Substring($baseLength)
+                        if ($path.StartsWith('\') -or $path.StartsWith('/')) {
+                            $path = $path.Substring(1)
+                        }
+                    }
+                }
+                return $path.Replace('\', '/')
+            }
+        }
+        
+        # Get all files in the repository
+        $allFiles = Get-ChildItem -Recurse -File -Force | Where-Object {
+            # Get relative path safely
+            $relativePath = Get-SafeRelativePath $_.FullName
+            
+            # Exclude files under .git directory specifically (not .github)
+            if ($relativePath -like '.git/*') {
+                return $false
+            }
+            
+            # Exclude hidden files (starting with .) except those in .github directory
+            $fileName = [System.IO.Path]::GetFileName($relativePath)
+            $isInGitHubDir = $relativePath -like '.github/*'
+            if ($fileName.StartsWith('.') -and -not $isInGitHubDir) {
+                return $false
+            }
+            
+            # Exclude files matching patterns using precise matching
+            $shouldExclude = $false
+            $pathSegments = $relativePath -split '[\\/]+'
+            $fileExtension = [System.IO.Path]::GetExtension($relativePath)
+            
+            foreach ($pattern in $excludePatterns) {
+                # Handle extension patterns like '*.user' or '*.suo'
+                if ($pattern.StartsWith('*.')) {
+                    $ext = $pattern.Substring(1)
+                    if ($fileExtension -ieq $ext) {
+                        $shouldExclude = $true
+                        break
+                    }
+                }
+                # Handle wildcard patterns like 'secrets*'
+                elseif ($pattern.Contains('*')) {
+                    if ($relativePath -like $pattern) {
+                        $shouldExclude = $true
+                        break
+                    }
+                }
+                # Treat as a path segment name and match against segments
+                else {
+                    if ($pathSegments -contains $pattern) {
+                        $shouldExclude = $true
+                        break
+                    }
+                }
+            }
+            
+            -not $shouldExclude
+        }
+        
+        # Group files by directory for .root structure
+        # Cache relative paths to avoid recalculating
+        $filesByDirectory = @{}
+        $relativePathCache = @{}
+        
+        foreach ($file in $allFiles) {
+            # Get relative path safely (use cached if available)
+            if (-not $relativePathCache.ContainsKey($file.FullName)) {
+                $relativePathCache[$file.FullName] = Get-SafeRelativePath $file.FullName
+            }
+            $relativePath = $relativePathCache[$file.FullName]
+            $directory = Split-Path $relativePath -Parent
+            if ([string]::IsNullOrEmpty($directory)) {
+                $directory = '.'
+            }
+            else {
+                $directory = $directory.Replace('\', '/')
+            }
+            
+            if (-not $filesByDirectory.ContainsKey($directory)) {
+                $filesByDirectory[$directory] = @()
+            }
+            $filesByDirectory[$directory] += $relativePath
+        }
+        
+        # Sort directories to ensure proper nesting order
+        $sortedDirectories = $filesByDirectory.Keys | Sort-Object
+        
+        # Build folder structure with XML escaping
+        foreach ($directory in $sortedDirectories) {
+            if ($directory -eq '.') {
+                # Root files
+                [void]$xmlBuilder.AppendLine('  <Folder Name="/.root/">')
+                foreach ($filePath in ($filesByDirectory[$directory] | Sort-Object)) {
+                    $escapedPath = [System.Security.SecurityElement]::Escape($filePath)
+                    [void]$xmlBuilder.AppendLine("    <File Path=""$escapedPath"" />")
+                }
+                [void]$xmlBuilder.AppendLine('  </Folder>')
+            }
+            else {
+                # Subdirectory files
+                $folderName = "/.root/$directory/"
+                $escapedFolderName = [System.Security.SecurityElement]::Escape($folderName)
+                [void]$xmlBuilder.AppendLine("  <Folder Name=""$escapedFolderName"">")
+                foreach ($filePath in ($filesByDirectory[$directory] | Sort-Object)) {
+                    $escapedPath = [System.Security.SecurityElement]::Escape($filePath)
+                    [void]$xmlBuilder.AppendLine("    <File Path=""$escapedPath"" />")
+                }
+                [void]$xmlBuilder.AppendLine('  </Folder>')
+            }
+        }
+        
+        # Add solution folders for benchmarks, examples, src, tests (only if directories exist)
+        # These are added after .root to prioritize configuration files in solution explorer
+        $solutionFolders = @('benchmarks', 'examples', 'src', 'tests')
+        foreach ($folder in $solutionFolders) {
+            if (Test-Path -Path $folder -PathType Container) {
+                [void]$xmlBuilder.AppendLine("  <Folder Name=""/$folder/"" />")
+            }
+        }
+        
+        [void]$xmlBuilder.AppendLine('</Solution>')
+        
+        # Write solution file with error handling
+        try {
+            Set-Content -Path $solutionFileName -Value $xmlBuilder.ToString() -ErrorAction Stop
+            Write-Success "Created solution file: $solutionFileName"
+            
+            # Show summary
+            $fileCount = $allFiles.Count
+            $folderCount = $filesByDirectory.Keys.Count
+            Write-Info "Added $fileCount files in $folderCount folders to .root/"
+        }
+        catch {
+            Write-TemplateWarning "Failed to create solution file '$solutionFileName'. Repository setup will continue."
+            Write-TemplateWarning "Error: $($_.Exception.Message)"
+            # Clear solutionFileName so Next Steps won't reference it
+            $solutionFileName = ''
+        }
+    }
+    
+    # Step 5: Validation
+    Write-Info "Step ${totalSteps}/${totalSteps}: Validating changes..."
+    
+    # Core placeholders that should have been replaced by the script
+    # Note: YEAR and COPYRIGHT_HOLDER are handled in LICENSE file generation, not in FILES_TO_UPDATE
+    $corePlaceholders = @(
+        'PROJECT_NAME', 'PROJECT_DESCRIPTION', 'PACKAGE_NAME',
+        'GITHUB_REPO_URL', 'REPO_NAME', 'GITHUB_USERNAME',
+        'DOCS_URL', 'LICENSE_TYPE',
+        'NUGET_STATUS', 'TEMPLATE_REPO_OWNER', 'TEMPLATE_REPO_NAME'
+    )
+    
+    # Optional placeholders that users fill in manually as they develop
+    $optionalPlaceholderDescriptions = @{
+        'QUICK_START_EXAMPLE' = 'Code example showing basic usage'
+        'FEATURES_TABLE' = 'Markdown table listing features'
+        'FEATURE_EXAMPLES' = 'Code examples demonstrating features'
+        'TARGET_FRAMEWORKS' = 'List of supported .NET frameworks'
+        'ACKNOWLEDGMENTS' = 'Credits for libraries/tools used'
+    }
+    
+    # Collect placeholders grouped by placeholder name
+    $corePlaceholdersByName = @{}
+    $optionalPlaceholdersByName = @{}
+    
+    foreach ($file in $filesToUpdate) {
+        if (Test-Path $file) {
+            $content = Get-Content $file -Raw
+            $matches = [regex]::Matches($content, '\{\{([A-Z_]+)\}\}')
+            foreach ($match in $matches) {
+                $placeholderName = $match.Groups[1].Value
+                
+                # Categorize placeholder
+                if ($corePlaceholders -contains $placeholderName) {
+                    if (-not $corePlaceholdersByName.ContainsKey($placeholderName)) {
+                        $corePlaceholdersByName[$placeholderName] = @()
+                    }
+                    if ($corePlaceholdersByName[$placeholderName] -notcontains $file) {
+                        $corePlaceholdersByName[$placeholderName] += $file
+                    }
+                }
+                elseif ($optionalPlaceholderDescriptions.ContainsKey($placeholderName)) {
+                    if (-not $optionalPlaceholdersByName.ContainsKey($placeholderName)) {
+                        $optionalPlaceholdersByName[$placeholderName] = @()
+                    }
+                    if ($optionalPlaceholdersByName[$placeholderName] -notcontains $file) {
+                        $optionalPlaceholdersByName[$placeholderName] += $file
+                    }
+                }
+            }
+        }
+    }
+    
+    # Report core placeholders that weren't replaced (this is an error)
+    if ($corePlaceholdersByName.Count -gt 0) {
+        Write-TemplateError "Error: The following required placeholders were not replaced:"
+        Write-Host ""
+        foreach ($placeholderName in ($corePlaceholdersByName.Keys | Sort-Object)) {
+            Write-Host "  {{$placeholderName}}" -ForegroundColor Red
+            Write-Host "    Found in:" -ForegroundColor Gray
+            foreach ($file in $corePlaceholdersByName[$placeholderName]) {
+                Write-Host "      - $file" -ForegroundColor Gray
+            }
+            Write-Host ""
+        }
+        Write-Warning "This indicates the script did not replace all required placeholders. Please review the files and replace these manually."
+        Write-Host ""
+        exit 1
+    }
+    else {
+        Write-Success "All required placeholders replaced successfully!"
+    }
+    
+    # Report optional placeholders that need manual updates
+    if ($optionalPlaceholdersByName.Count -gt 0) {
+        Write-Host ""
+        Write-Info "Optional content placeholders to fill in as you develop your project:"
+        Write-Host ""
+        
+        foreach ($placeholderName in ($optionalPlaceholdersByName.Keys | Sort-Object)) {
+            $description = $optionalPlaceholderDescriptions[$placeholderName]
+            
+            Write-Host "  {{$placeholderName}}" -ForegroundColor Yellow
+            Write-Host "    Description: $description" -ForegroundColor Gray
+            Write-Host "    Found in:" -ForegroundColor Gray
+            foreach ($file in $optionalPlaceholdersByName[$placeholderName]) {
+                Write-Host "      - $file" -ForegroundColor Gray
+            }
+            Write-Host ""
+        }
+        Write-Info "See TEMPLATE-PLACEHOLDERS.md for details on each placeholder."
+    }
+    
+    # Optional cleanup
+    Write-Step "Cleanup"
+    Write-Host ""
+    Write-Host "Remove template-specific files? (y/N)" -ForegroundColor Yellow
+    Write-Host "  Files to remove:" -ForegroundColor Gray
+    Write-Host "    - scripts/setup.ps1 (this script)" -ForegroundColor Gray
+    Write-Host "    - LICENSE-SELECTION.md" -ForegroundColor Gray
+    Write-Host ""
+    Write-Host "  Note: TEMPLATE-PLACEHOLDERS.md will remain for your reference." -ForegroundColor Cyan
+    Write-Host "        Delete it manually when you've reviewed it and no longer need it." -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "Remove template files? (y/N): " -NoNewline -ForegroundColor Yellow
+    $cleanup = Read-Host
+    
+    if ($cleanup -eq 'y' -or $cleanup -eq 'Y') {
+        $filesToRemove = @(
+            'scripts/setup.ps1',
+            'LICENSE-SELECTION.md'
+        )
+        
+        foreach ($file in $filesToRemove) {
+            if (Test-Path $file) {
+                Remove-Item $file -Force
+                Write-Success "Removed: $file"
+            }
+        }
+    }
+    else {
+        Write-Info "Keeping template files. You can remove them manually later."
+    }
+    
+    # Success!
+    Write-Host ""
+    Write-Host "╔════════════════════════════════════════════════════════════════╗" -ForegroundColor Green
+    Write-Host "║                                                                ║" -ForegroundColor Green
+    Write-Host "║                    🎉 Setup Complete! 🎉                       ║" -ForegroundColor Green
+    Write-Host "║                                                                ║" -ForegroundColor Green
+    Write-Host "╚════════════════════════════════════════════════════════════════╝" -ForegroundColor Green
+    Write-Host ""
+    
+    # Git operations
+    Write-Step "Git Operations"
+    Write-Host ""
+    
+    # Step 1: Create branch and commit changes
+    Write-Host "Create a branch and commit these changes? (Y/n): " -NoNewline -ForegroundColor Yellow
+    $commitChanges = Read-Host
+    if ([string]::IsNullOrEmpty($commitChanges) -or $commitChanges -eq 'Y' -or $commitChanges -eq 'y') {
+        # Generate branch name
+        $branchName = "setup/configure-from-template-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+        
+        Write-Info "Step 1/4: Creating branch '$branchName'..."
+        git checkout -b $branchName
+        if ($LASTEXITCODE -eq 0) {
+            Write-Success "Branch created successfully!"
+            Write-Host ""
+            
+            Write-Info "Step 2/4: Committing changes..."
+            git add .
+            if ($LASTEXITCODE -eq 0) {
+                git commit -m "Configure repository from template"
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Success "Changes committed successfully!"
+                    Write-Host ""
+                    
+                    # Step 3: Push to GitHub
+                    Write-Info "Step 3/4: Pushing branch to GitHub..."
+                    git push -u origin $branchName
+                    if ($LASTEXITCODE -eq 0) {
+                        Write-Success "Branch pushed to GitHub successfully!"
+                        Write-Host ""
+                        
+                        # Step 4: Create Pull Request
+                        Write-Info "Step 4/4: Creating pull request..."
+                        
+                        # Check if gh command is available
+                        try {
+                            $null = Get-Command gh -ErrorAction Stop
+                            
+                            gh pr create --title "Configure repository from template" --body "This PR contains the initial repository configuration from the template setup script.`n`nPlease review the changes, make any necessary adjustments, and merge to main when ready." --base main --head $branchName
+                            if ($LASTEXITCODE -eq 0) {
+                                Write-Success "Pull request created successfully!"
+                                Write-Host ""
+                                
+                                # Get PR URL (best-effort; fall back to generic instruction on failure)
+                                $prUrl = gh pr view $branchName --json url --jq .url 2>$null
+                                if ($LASTEXITCODE -eq 0 -and $prUrl) {
+                                    Write-Host "╔════════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
+                                    Write-Host "║                                                                ║" -ForegroundColor Cyan
+                                    Write-Host "║                       📋 Review Required                       ║" -ForegroundColor Cyan
+                                    Write-Host "║                                                                ║" -ForegroundColor Cyan
+                                    Write-Host "╚════════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+                                    Write-Host ""
+                                    Write-Host "Branch: $branchName" -ForegroundColor Yellow
+                                    Write-Host "Pull Request: $prUrl" -ForegroundColor Yellow
+                                    Write-Host ""
+                                    Write-Info "Please review the pull request, make any necessary changes, and merge it to main before continuing with development."
+                                    Write-Host ""
+                                }
+                                else {
+                                    Write-Host "╔════════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
+                                    Write-Host "║                                                                ║" -ForegroundColor Cyan
+                                    Write-Host "║                       📋 Review Required                       ║" -ForegroundColor Cyan
+                                    Write-Host "║                                                                ║" -ForegroundColor Cyan
+                                    Write-Host "╚════════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+                                    Write-Host ""
+                                    Write-Host "Branch: $branchName" -ForegroundColor Yellow
+                                    Write-Host ""
+                                    Write-Info "Please review the pull request, make any necessary changes, and merge it to main before continuing with development."
+                                    Write-Info "You can view the pull request with: gh pr view $branchName --web"
+                                    Write-Host ""
+                                }
+                            }
+                            else {
+                                Write-TemplateWarning "Failed to create pull request. You can create it manually with:"
+                                Write-Host "  gh pr create --title ""Configure repository from template"" --body ""Initial setup"" --base main --head $branchName" -ForegroundColor Gray
+                                Write-Host ""
+                            }
+                        }
+                        catch {
+                            Write-TemplateWarning "GitHub CLI (gh) is not installed or not available in PATH."
+                            Write-TemplateWarning "Please install it from https://cli.github.com/ to enable automatic PR creation."
+                            Write-Host ""
+                            Write-Info "You can create the pull request manually with:"
+                            Write-Host "  gh pr create --title ""Configure repository from template"" --body ""Initial setup"" --base main --head $branchName" -ForegroundColor Gray
+                            Write-Host ""
+                        }
+                    }
+                    else {
+                        Write-TemplateWarning "Push failed. You can push manually later with:"
+                        Write-Host "  git push -u origin $branchName" -ForegroundColor Gray
+                        Write-Host ""
+                    }
+                }
+                else {
+                    Write-TemplateWarning "Commit failed. You can commit manually later with:"
+                    Write-Host "  git commit -m ""Configure repository from template""" -ForegroundColor Gray
+                    Write-Host "  git push -u origin $branchName" -ForegroundColor Gray
+                    Write-Host ""
+                }
+            }
+            else {
+                Write-TemplateWarning "Git add failed. You can commit manually later with:"
+                Write-Host "  git add ." -ForegroundColor Gray
+                Write-Host "  git commit -m ""Configure repository from template""" -ForegroundColor Gray
+                Write-Host "  git push -u origin $branchName" -ForegroundColor Gray
+                Write-Host ""
+            }
+        }
+        else {
+            Write-TemplateWarning "Failed to create branch. You can create it manually with:"
+            Write-Host "  git checkout -b $branchName" -ForegroundColor Gray
+            Write-Host "  git add ." -ForegroundColor Gray
+            Write-Host "  git commit -m ""Configure repository from template""" -ForegroundColor Gray
+            Write-Host "  git push -u origin $branchName" -ForegroundColor Gray
+            Write-Host ""
+        }
+    }
+    else {
+        Write-Info "Skipping branch creation and commit. You can do this manually later with:"
+        Write-Host "  git checkout -b setup/configure-from-template-<timestamp>" -ForegroundColor Gray
+        Write-Host "  git add ." -ForegroundColor Gray
+        Write-Host "  git commit -m ""Configure repository from template""" -ForegroundColor Gray
+        Write-Host "  git push -u origin setup/configure-from-template-<timestamp>" -ForegroundColor Gray
+        Write-Host "  gh pr create --title ""Configure repository from template"" --base main" -ForegroundColor Gray
+        Write-Host ""
+    }
+    
+    # Next steps
+    Write-Host "✅ Next Steps:" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "1. Configure branch protection (see REPO-INSTRUCTIONS.md if kept)" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "2. Start developing!" -ForegroundColor Yellow
+    if ($solutionName) {
+        Write-Host "   # Solution file created: $solutionName.slnx" -ForegroundColor Gray
+        Write-Host "   # Add your projects to src/ and tests/" -ForegroundColor Gray
+    }
+    else {
+        Write-Host "   dotnet new sln -n $projectName" -ForegroundColor Gray
+        Write-Host "   # Add your projects to src/ and tests/" -ForegroundColor Gray
+    }
+    Write-Host ""
+    
+    Write-Info "Your repository is now configured and ready for development!"
+    Write-Host ""
+}
+
+# Run setup
+try {
+    Start-Setup
+}
+catch {
+    Write-Error "Setup failed: $_"
+    Write-Host $_.ScriptStackTrace -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
## Summary
Adds four scripts from the canonical `repo-template` that were missing from this repo:

- `scripts/setup.ps1`
- `scripts/format.ps1`
- `scripts/Setup-Labels.ps1`
- `scripts/Setup-GitHubPages.ps1` — placeholders already substituted for `Chris-Wolfgang/IComparable-Extensions`

## Test plan
- [ ] Scripts run without error on Windows PowerShell