### PR TITLE
Fix pack-and-validate: drop 'src/' arg from restore and build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -364,10 +364,10 @@ jobs:
             10.0.x
 
       - name: Restore source projects
-        run: dotnet restore src/
+        run: dotnet restore
 
       - name: Build Source Projects (Release)
-        run: dotnet build --no-restore --configuration Release src/
+        run: dotnet build --no-restore --configuration Release
 
       - name: Pack NuGet Packages
         id: check-packages


### PR DESCRIPTION
## Summary
Drops the `src/` argument from the `Restore source projects` and `Build Source Projects (Release)` steps in the `pack-and-validate` job to match the canonical [repo-template](https://github.com/Chris-Wolfgang/repo-template).

## Why
The v1.1.0 release run failed with:

```
MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.
```

`dotnet restore src/` and `dotnet build src/` treat `src/` as a project/solution path. It must contain a top-level `.csproj`, `.sln`, or `.slnx` for that to work — but here `src/` only has subdirectories (`src/Wolfgang.Extensions.IComparable/Wolfgang.Extensions.IComparable.csproj`), so dotnet falls back to the cwd and fails because the slnx is at the repo root.

The canonical repo-template doesn't scope these commands. Every other repo on this template (ETL-Json, IEnumerable-Extensions, etc.) uses the unscoped form and packs successfully.

## Test plan
- [ ] After merge, re-cut a release and confirm `Pack & Validate NuGet` succeeds