### PR TITLE
Fix unfilled docfx.json placeholder

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -5,7 +5,7 @@
       "src": [
         {
           "files": [
-			"src/<path>/<project>.csproj"
+			"src/**/*.csproj"
           ],
           "src": "../"
         }


### PR DESCRIPTION
## Summary
Replaces the unfilled `src/<path>/<project>.csproj` placeholder in `docfx_project/docfx.json` with the `src/**/*.csproj` glob pattern.

## Why
`scripts/setup.ps1` was supposed to substitute the placeholder at template-bootstrap time but never did, leaving docfx unable to locate the csproj for metadata extraction. The result: docfx builds the site but produces no `api/` directory, and the workflow's "Verify build output" step then fails.

Aligns with the pattern used by Try-Pattern, ETL-Abstractions, and other working repos. Glob is more robust than a hardcoded path because it auto-picks up any csproj added under `src/`.

## Audit
This issue affects exactly 2 repos out of 25 — IComparable-Extensions and IEnumerable-Extensions. Both are getting the same fix.

## Test plan
- [ ] CI green
- [ ] After merge, manually trigger `docfx.yaml` and verify `gh-pages` is populated
- [ ] After gh-pages is populated, switch GitHub Pages source to `gh-pages`/`/` (currently misconfigured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)