### PR TITLE
pr.yaml: add [trusted=yes] to focal-security apt source

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -327,7 +327,11 @@ jobs:
       # repository so APT verifies the package via GPG instead of a plain wget download.
       - name: Install OpenSSL 1.1 for .NET 5.0
         run: |
-          echo "deb https://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
+          # [trusted=yes] skips GPG signature verification — the focal Ubuntu archive
+          # signing key is not always present on newer GitHub-hosted runners, which
+          # caused the apt source to be silently ignored and 'libssl1.1' to fail with
+          # 'has no installation candidate'.
+          echo "deb [trusted=yes] https://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
           sudo apt-get update -q
           sudo apt-get install --yes libssl1.1
           sudo rm /etc/apt/sources.list.d/focal-security.list


### PR DESCRIPTION
## Summary
Adds \`[trusted=yes]\` to the \`focal-security\` apt source line in pr.yaml's "Install OpenSSL 1.1 for .NET 5.0" step.

## Why
The step is currently failing on newer GitHub-hosted Ubuntu runners with:
\`\`\`
E: Package 'libssl1.1' has no installation candidate
\`\`\`

Root cause: the focal Ubuntu archive signing key is not always present on newer runner images. apt silently \`Ign\`'s the source (\`Ign:55 ... focal-security InRelease\`), \`apt-get update\` succeeds *without* it, so \`libssl1.1\` isn't in the package index when install runs.

\`[trusted=yes]\` skips GPG signature verification, letting the source be used regardless of key availability.

## Testing approach
This is a "test in one repo first" change. If CI on this PR (or a re-run of #68) succeeds at the install step, propagate the fix to canonical \`repo-template\` and roll out to the other ~19 repos that have .NET 5.0 in their test matrix.

## Note about CI on this PR itself
The PR uses \`pull_request_target\`, which runs the workflow from \`main\` (not from the PR branch). So this PR's own CI will run the *unfixed* step — and likely still fail. The fix only takes effect once it's *on main*. Validation will be by re-running an existing PR (e.g. #68) after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)