### PR TITLE
pr.yaml: use signed-by for focal-security instead of [trusted=yes]

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -324,14 +324,16 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       # Fix for .NET 5.0 on Ubuntu 22.04+ - install libssl1.1 from the focal-security
-      # repository so APT verifies the package via GPG instead of a plain wget download.
+      # repository, with GPG verification bound to the Ubuntu archive keyring that
+      # ships in the base runner image.
       - name: Install OpenSSL 1.1 for .NET 5.0
         run: |
-          # [trusted=yes] skips GPG signature verification — the focal Ubuntu archive
-          # signing key is not always present on newer GitHub-hosted runners, which
-          # caused the apt source to be silently ignored and 'libssl1.1' to fail with
-          # 'has no installation candidate'.
-          echo "deb [trusted=yes] https://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
+          # signed-by=... pins this source to the Ubuntu archive keyring instead of
+          # relying on apt's default trusted set. Without this, newer GitHub-hosted
+          # runners silently 'Ign' the source and 'libssl1.1' fails with
+          # 'has no installation candidate'. Keyring path is the canonical location
+          # in every Ubuntu image.
+          echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
           sudo apt-get update -q
           sudo apt-get install --yes libssl1.1
           sudo rm /etc/apt/sources.list.d/focal-security.list


### PR DESCRIPTION
## Summary
Replaces `[trusted=yes]` (added in #69) with `[signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg]` so apt still verifies the `libssl1.1` package signature.

## Why
Copilot flagged `[trusted=yes]` on [repo-template#336](https://github.com/Chris-Wolfgang/repo-template/pull/336):

> Using `deb [trusted=yes] ...` disables APT signature verification for the focal-security repo, which reintroduces a supply-chain risk (MITM/malicious mirror) during `apt-get update/install`. Prefer keeping verification by installing/importing the Ubuntu archive signing key into a dedicated keyring and referencing it via `signed-by=...`.

Valid concern. `signed-by=` pins the focal-security source to the Ubuntu archive keyring that already ships in the base runner image (`/usr/share/keyrings/ubuntu-archive-keyring.gpg`) — keeping verification on while still working around the default-trusted-set issue that caused the original failure.

## Validation
This PR is the validation step. If CI goes green, the same change rolls forward to repo-template#336 and the 18 downstream PRs that already merged-in or are queuing the `[trusted=yes]` version.