### PR TITLE
chore: keep docs at /docs/, point docfx at them

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -16,12 +16,19 @@
   "build": {
     "content": [
       {
-		"files": [
-			"**/*.{md,yml}"
-		],
+        "files": [
+          "**/*.{md,yml}"
+        ],
         "exclude": [
           "_site/**"
         ]
+      },
+      {
+        "files": [
+          "**/*.{md,yml}"
+        ],
+        "src": "../docs",
+        "dest": "docs"
       }
     ],
     "resource": [

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -1,1 +1,0 @@
-# Getting Started

--- a/docfx_project/docs/introduction.md
+++ b/docfx_project/docs/introduction.md
@@ -1,1 +1,0 @@
-# Introduction

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,191 @@
+# Getting Started
+
+This guide will help you quickly start using Wolfgang.Extensions.IComparable in your .NET projects.
+
+## Prerequisites
+
+- .NET 8.0 or later
+- A C# project (any project type: console, web, library, etc.)
+
+## Installation
+
+### Using NuGet Package Manager
+
+```bash
+dotnet add package Wolfgang.Extensions.IComparable
+```
+
+### Using Package Manager Console (Visual Studio)
+
+```powershell
+Install-Package Wolfgang.Extensions.IComparable
+```
+
+### Using .csproj File
+
+Add the following package reference to your `.csproj` file:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Wolfgang.Extensions.IComparable" Version="1.*" />
+</ItemGroup>
+```
+
+## Basic Usage
+
+### 1. Add the Using Directive
+
+Add the namespace to your C# file:
+
+```csharp
+using Wolfgang.Extensions.IComparable;
+```
+
+### 2. Use IsBetween Method
+
+Check if a value is strictly between two bounds (exclusive):
+
+```csharp
+int temperature = 25;
+
+if (temperature.IsBetween(0, 30))
+{
+    Console.WriteLine("Temperature is between 0 and 30 (exclusive)");
+}
+```
+
+**Example Results:**
+- `5.IsBetween(1, 10)` → `true` (5 is greater than 1 and less than 10)
+- `1.IsBetween(1, 10)` → `false` (1 is not greater than 1)
+- `10.IsBetween(1, 10)` → `false` (10 is not less than 10)
+
+### 3. Use IsInRange Method
+
+Check if a value is within a range (inclusive):
+
+```csharp
+int score = 85;
+
+if (score.IsInRange(0, 100))
+{
+    Console.WriteLine("Score is within the valid range of 0-100");
+}
+```
+
+**Example Results:**
+- `5.IsInRange(1, 10)` → `true` (5 is between 1 and 10)
+- `1.IsInRange(1, 10)` → `true` (1 equals the lower bound)
+- `10.IsInRange(1, 10)` → `true` (10 equals the upper bound)
+
+## Common Examples
+
+### Validating User Input
+
+```csharp
+int age = GetUserAge();
+
+if (age.IsInRange(0, 120))
+{
+    Console.WriteLine("Valid age entered");
+}
+else
+{
+    Console.WriteLine("Age must be between 0 and 120");
+}
+```
+
+### Working with Decimals
+
+```csharp
+decimal price = 49.99m;
+
+if (price.IsBetween(0m, 100m))
+{
+    Console.WriteLine("Price is in the medium range");
+}
+```
+
+### Working with Dates
+
+```csharp
+DateTime checkDate = new DateTime(2024, 6, 15);
+DateTime startDate = new DateTime(2024, 1, 1);
+DateTime endDate = new DateTime(2024, 12, 31);
+
+if (checkDate.IsInRange(startDate, endDate))
+{
+    Console.WriteLine("Date falls within 2024");
+}
+```
+
+### Working with Strings
+
+```csharp
+string value = "M";
+
+// String comparison is alphabetical
+if (value.IsBetween("A", "Z"))
+{
+    Console.WriteLine("Value is between A and Z (exclusive)");
+}
+```
+
+### Working with Custom Types
+
+```csharp
+public class Employee : IComparable<Employee>
+{
+    public string Name { get; set; }
+    public decimal Salary { get; set; }
+    
+    public int CompareTo(Employee other)
+    {
+        return Salary.CompareTo(other.Salary);
+    }
+}
+
+var employee = new Employee { Name = "John", Salary = 50000 };
+var minSalary = new Employee { Salary = 30000 };
+var maxSalary = new Employee { Salary = 100000 };
+
+if (employee.IsInRange(minSalary, maxSalary))
+{
+    Console.WriteLine("Employee salary is within the expected range");
+}
+```
+
+## Quick Reference
+
+| Method | Comparison Type | Lower Bound | Upper Bound | Example |
+|--------|----------------|-------------|-------------|---------|
+| `IsBetween` | Exclusive | `>` | `<` | `5.IsBetween(1, 10)` → `true` |
+| `IsInRange` | Inclusive | `>=` | `<=` | `1.IsInRange(1, 10)` → `true` |
+
+## Next Steps
+
+- Explore more [advanced usage examples](./readme.md)
+- Learn about [setting up your development environment](./setup.md)
+- Read the full [introduction](./introduction.md) to understand the library's design
+
+## Troubleshooting
+
+### Namespace Not Found
+
+If you get a compile error that the namespace cannot be found:
+1. Ensure the package is properly installed (`dotnet restore`)
+2. Verify you're using .NET 8.0 or later
+3. Check that your IDE has indexed the new package (restart if necessary)
+
+### Method Not Available
+
+If the extension methods don't appear:
+1. Ensure you've added the `using Wolfgang.Extensions.IComparable;` directive
+2. Verify your type implements `IComparable<T>`
+3. Check that IntelliSense has refreshed (rebuild the solution)
+
+## Getting Help
+
+If you encounter any issues:
+- Check the [GitHub Issues](https://github.com/Chris-Wolfgang/IComparable-Extensions/issues)
+- Review the [examples](../examples/) in the repository
+- Read the [API documentation](../README.md)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,82 @@
+# Introduction
+
+## Overview
+
+**Wolfgang.Extensions.IComparable** is a lightweight .NET library that provides powerful extension methods for types implementing the `IComparable<T>` interface. This library simplifies common comparison operations, making your code more readable and expressive.
+
+## What is IComparable?
+
+The `IComparable<T>` interface is a fundamental part of .NET that allows objects to be compared for ordering purposes. Types that implement this interface can be sorted and compared using standardized methods.
+
+## Why Use This Library?
+
+When working with comparable types in C#, you often need to check if a value falls within a specific range. Without this library, such checks can be verbose and error-prone:
+
+```csharp
+// Without Wolfgang.Extensions.IComparable
+if (value.CompareTo(min) >= 0 && value.CompareTo(max) <= 0)
+{
+    // Value is in range
+}
+
+// With Wolfgang.Extensions.IComparable
+if (value.IsInRange(min, max))
+{
+    // Value is in range - much clearer!
+}
+```
+
+## Key Features
+
+- **Intuitive API**: Extension methods that read like natural language
+- **Type-Safe**: Works with any type that implements `IComparable<T>`
+- **Zero Dependencies**: Lightweight library with no external dependencies
+- **Well-Tested**: Comprehensive test coverage to ensure reliability
+- **Performance-Optimized**: Minimal overhead compared to manual comparison operations
+
+## Available Extension Methods
+
+### IsBetween
+
+Determines if a value is **strictly between** two bounds (exclusive comparison):
+
+```csharp
+int value = 5;
+bool result = value.IsBetween(1, 10); // true (5 > 1 AND 5 < 10)
+```
+
+### IsInRange
+
+Determines if a value is **within the range** of two bounds (inclusive comparison):
+
+```csharp
+int value = 5;
+bool result = value.IsInRange(5, 10); // true (5 >= 5 AND 5 <= 10)
+```
+
+## Use Cases
+
+This library is particularly useful in scenarios such as:
+
+- **Validation**: Checking if user input falls within acceptable ranges
+- **Business Logic**: Implementing rules that depend on value ranges
+- **Data Processing**: Filtering or categorizing data based on value ranges
+- **Game Development**: Checking bounds for positions, scores, or other metrics
+- **Financial Applications**: Validating amounts, dates, or other comparable values
+
+## Supported Types
+
+Any type that implements `IComparable<T>` can use these extension methods, including:
+
+- Numeric types: `int`, `double`, `decimal`, `float`, etc.
+- Date and time types: `DateTime`, `DateTimeOffset`, `TimeSpan`
+- String comparisons
+- Custom types that implement `IComparable<T>`
+
+## License
+
+This project is licensed under the Mozilla Public License 2.0. See the [LICENSE](../LICENSE) file for details.
+
+## Contributing
+
+We welcome contributions! Please see our [CONTRIBUTING.md](../CONTRIBUTING.md) guide for more information.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,357 @@
+# Development Setup Guide
+
+This guide will help you set up your development environment to contribute to Wolfgang.Extensions.IComparable.
+
+## Prerequisites
+
+Before you begin, ensure you have the following installed:
+
+### Required Software
+
+1. **.NET 8.0 SDK** or later
+   - Download from [dotnet.microsoft.com](https://dotnet.microsoft.com/download)
+   - Verify installation: `dotnet --version`
+
+2. **Git**
+   - Download from [git-scm.com](https://git-scm.com/)
+   - Verify installation: `git --version`
+
+3. **A Code Editor** (choose one):
+   - [Visual Studio 2022](https://visualstudio.microsoft.com/) (Community, Professional, or Enterprise)
+   - [Visual Studio Code](https://code.visualstudio.com/) with C# extension
+   - [JetBrains Rider](https://www.jetbrains.com/rider/)
+
+### Recommended Tools
+
+1. **ReportGenerator** (for code coverage reports)
+   ```bash
+   dotnet tool install -g dotnet-reportgenerator-globaltool
+   ```
+
+2. **DevSkim CLI** (for security scanning)
+   ```bash
+   dotnet tool install --global Microsoft.CST.DevSkim.CLI
+   ```
+
+## Getting the Source Code
+
+### 1. Fork the Repository
+
+1. Navigate to [https://github.com/Chris-Wolfgang/IComparable-Extensions](https://github.com/Chris-Wolfgang/IComparable-Extensions)
+2. Click the **Fork** button in the upper right
+3. Select your GitHub account as the destination
+
+### 2. Clone Your Fork
+
+```bash
+# Clone your fork
+git clone https://github.com/YOUR-USERNAME/IComparable-Extensions.git
+
+# Navigate to the repository
+cd IComparable-Extensions
+
+# Add upstream remote
+git remote add upstream https://github.com/Chris-Wolfgang/IComparable-Extensions.git
+```
+
+### 3. Verify Your Setup
+
+```bash
+# Check remotes
+git remote -v
+
+# Should show:
+# origin    https://github.com/YOUR-USERNAME/IComparable-Extensions.git (fetch)
+# origin    https://github.com/YOUR-USERNAME/IComparable-Extensions.git (push)
+# upstream  https://github.com/Chris-Wolfgang/IComparable-Extensions.git (fetch)
+# upstream  https://github.com/Chris-Wolfgang/IComparable-Extensions.git (push)
+```
+
+## Building the Project
+
+### 1. Restore Dependencies
+
+```bash
+dotnet restore
+```
+
+### 2. Build the Solution
+
+```bash
+# Build in Debug mode
+dotnet build
+
+# Build in Release mode (recommended for testing)
+dotnet build --configuration Release
+```
+
+Expected output:
+```
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+```
+
+## Running Tests
+
+### Run All Tests
+
+```bash
+dotnet test --configuration Release
+```
+
+### Run Tests with Code Coverage
+
+```bash
+# Run tests and collect coverage
+dotnet test --configuration Release --collect:"XPlat Code Coverage" --results-directory "./TestResults"
+
+# Generate coverage report (if ReportGenerator is installed)
+reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" \
+                -targetdir:"CoverageReport" \
+                -reporttypes:"Html;TextSummary"
+
+# View the report
+# Open CoverageReport/index.html in your browser
+```
+
+### Run Specific Test Projects
+
+```bash
+# Run only unit tests
+dotnet test tests/Wolfgang.Extensions.IComparable.Tests/Wolfgang.Extensions.IComparable.Tests.csproj
+```
+
+## Code Quality Checks
+
+### Run Security Scanning
+
+```bash
+# Run DevSkim security analysis
+devskim analyze --source-code . -f text --output-file devskim-results.txt
+
+# View results
+cat devskim-results.txt
+```
+
+### Check Code Style
+
+The project uses `.editorconfig` for consistent code style. Most IDEs will automatically apply these rules.
+
+To manually check:
+```bash
+# Format code
+dotnet format
+
+# Verify formatting
+dotnet format --verify-no-changes
+```
+
+## Running Benchmarks
+
+If you're working on performance improvements:
+
+```bash
+# Navigate to benchmarks
+cd benchmarks
+
+# Run benchmarks
+dotnet run --configuration Release
+```
+
+## Project Structure
+
+```
+IComparable-Extensions/
+├── src/
+│   └── Wolfgang.Extensions.IComparable/
+│       ├── Wolfgang.Extensions.IComparable.csproj
+│       └── IComparableExtensions.cs
+├── tests/
+│   └── Wolfgang.Extensions.IComparable.Tests/
+│       ├── Wolfgang.Extensions.IComparable.Tests.csproj
+│       └── IComparableExtensionsTests.cs
+├── benchmarks/
+│   └── (Benchmark projects)
+├── examples/
+│   └── (Example projects)
+├── docs/
+│   ├── introduction.md
+│   ├── getting-started.md
+│   ├── readme.md
+│   └── setup.md
+├── .github/
+│   └── workflows/
+│       └── pr.yaml (CI/CD pipeline)
+├── .editorconfig (Code style rules)
+├── .gitignore
+├── IComparable-Extensions.slnx (Solution file)
+├── README.md
+└── LICENSE
+```
+
+## Development Workflow
+
+### 1. Create a Feature Branch
+
+```bash
+# Update your main branch
+git checkout main
+git pull upstream main
+
+# Create a new feature branch
+git checkout -b feature/your-feature-name
+```
+
+### 2. Make Your Changes
+
+- Write code following the existing style
+- Add or update tests for your changes
+- Ensure tests pass: `dotnet test`
+- Ensure coverage meets requirements (≥80%)
+
+### 3. Commit Your Changes
+
+```bash
+# Stage your changes
+git add .
+
+# Commit with a descriptive message
+git commit -m "Add feature: description of your changes"
+```
+
+### 4. Push and Create Pull Request
+
+```bash
+# Push to your fork
+git push origin feature/your-feature-name
+```
+
+Then:
+1. Go to your fork on GitHub
+2. Click "Compare & pull request"
+3. Fill out the PR template
+4. Submit the pull request
+
+## CI/CD Pipeline
+
+The project uses GitHub Actions for continuous integration. On every pull request:
+
+1. **Build Check**: Code is built in Release mode
+2. **Test Execution**: All tests are run
+3. **Code Coverage**: Coverage is collected and must be ≥80%
+4. **Security Scan**: DevSkim analyzes for security vulnerabilities
+5. **Artifacts**: Coverage reports and scan results are uploaded
+
+### Local CI Simulation
+
+To simulate the CI pipeline locally:
+
+```bash
+# Clean previous builds
+dotnet clean
+
+# Restore dependencies
+dotnet restore
+
+# Build in Release mode
+dotnet build --no-restore --configuration Release
+
+# Run tests with coverage
+find ./tests -type f -name '*Test*.csproj' | while read proj; do
+  dotnet test "$proj" --no-build --configuration Release \
+    --collect:"XPlat Code Coverage" \
+    --results-directory "./TestResults"
+done
+
+# Generate coverage report
+reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" \
+                -targetdir:"CoverageReport" \
+                -reporttypes:"Html;TextSummary;MarkdownSummaryGithub;CsvSummary"
+
+# Run security scan
+devskim analyze --source-code . -f text --output-file devskim-results.txt -E
+```
+
+## Troubleshooting
+
+### Build Errors
+
+**Problem**: `The SDK 'Microsoft.NET.Sdk' specified could not be found`
+- **Solution**: Install .NET 8.0 SDK from [dotnet.microsoft.com](https://dotnet.microsoft.com/download)
+
+**Problem**: `Package restore failed`
+- **Solution**: 
+  ```bash
+  dotnet nuget locals all --clear
+  dotnet restore
+  ```
+
+### Test Failures
+
+**Problem**: Tests pass locally but fail in CI
+- **Solution**: Ensure you're building in Release mode: `dotnet test --configuration Release`
+
+**Problem**: Code coverage below 80%
+- **Solution**: Add tests for uncovered code paths
+
+### Git Issues
+
+**Problem**: Merge conflicts
+- **Solution**:
+  ```bash
+  git fetch upstream
+  git merge upstream/main
+  # Resolve conflicts in your editor
+  git add .
+  git commit -m "Merge upstream changes"
+  ```
+
+## Editor Configuration
+
+### Visual Studio Code
+
+Recommended extensions:
+- C# (Microsoft)
+- C# Dev Kit (Microsoft)
+- EditorConfig for VS Code
+
+Settings (`.vscode/settings.json`):
+```json
+{
+  "dotnet.defaultSolution": "IComparable-Extensions.slnx",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  }
+}
+```
+
+### Visual Studio
+
+The solution should work out of the box. Ensure:
+- Code cleanup is configured to use `.editorconfig` rules
+- Code analysis is enabled
+
+### JetBrains Rider
+
+Rider automatically respects `.editorconfig`. Additional settings:
+- Enable "Reformat code on save"
+- Enable "Optimize imports on save"
+
+## Getting Help
+
+If you encounter issues:
+
+1. Check [existing GitHub issues](https://github.com/Chris-Wolfgang/IComparable-Extensions/issues)
+2. Review the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
+3. Ask questions in a new GitHub issue
+
+## Next Steps
+
+- Read the [Contributing Guidelines](../CONTRIBUTING.md)
+- Review the [Code of Conduct](../CODE_OF_CONDUCT.md)
+- Explore the [examples](../examples/) folder
+- Join the community discussions
+
+Happy coding! 🚀

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,5 +1,3 @@
-- name: Index
-  href: Index.md
 - name: Introduction
   href: introduction.md
 - name: Getting Started


### PR DESCRIPTION
## Summary
Restores user-facing docs at root `/docs/` (where they're naturally discoverable on GitHub) and configures docfx to read from there. Reverses the empty-stubs-being-published bug while keeping the canonical principle that user-facing docs are at root `/docs/`, not buried in `docfx_project/docs/`.

## Background
Two related issues converged:

1. The repo originally had real docs at `/docs/getting-started.md`, `introduction.md`, `setup.md`, plus duplicates / placeholders (`readme.md`, `index.html`).
2. The repo-template scaffolds `docfx_project/docs/` with 17-byte and 14-byte stubs (`# Getting Started`, `# Introduction`).
3. `docfx_project/docfx.json`'s `build.content` only walks `docfx_project/`, so the real content at `/docs/` was never published — only the stubs were.
4. Commit eac0e68 deleted `/docs/` entirely with the rationale that those files weren't published anyway. But the underlying problem was the docfx config, not the location.

## Changes
- **Restore** real content under `/docs/`:
  - `docs/getting-started.md` (4395B)
  - `docs/introduction.md` (2807B)
  - `docs/setup.md` (8519B contributor setup guide)
- **Move** `docfx_project/docs/toc.yml` → `docs/toc.yml`, drop broken `Index.md` entry
- **Delete** `docfx_project/docs/getting-started.md` and `introduction.md` (empty stubs)
- **Update** `docfx_project/docfx.json`: add a second `build.content` entry sourcing from `../docs` with `dest: docs` so the published site has `/docs/getting-started.html`, `/docs/introduction.html`, etc.

## Not restored from history
- `docs/readme.md` — was a duplicate of root `README.md`
- `docs/index.html` — was a stale placeholder (`Welcome to {repository name}`)

## Why /docs/ rather than docfx_project/docs/
- Root `/docs/` is conventional and discoverable on GitHub
- One canonical location eliminates the stub-vs-real-content failure mode
- Co-located with `README.md` and `CONTRIBUTING.md`

## Test plan
- [ ] After merge, manually trigger the `Deploy DocFX Pages` workflow
- [ ] Verify https://chris-wolfgang.github.io/IComparable-Extensions/docs/getting-started.html shows real content
- [ ] Verify left-nav shows Introduction / Getting Started / Project website