### PR TITLE
D5: audit other markdown files (closes #103)

### DIFF
--- a/docfx_project/index.md
+++ b/docfx_project/index.md
@@ -2,8 +2,41 @@
 _layout: landing
 ---
 
-# Title
+# Wolfgang.Extensions.IComparable Documentation
 
-## Quick Start Notes:
+Welcome to the Wolfgang.Extensions.IComparable documentation. This site contains the API reference and getting-started guides for the library.
 
-<!--1. Add images to the *images* folder if the file is referencing an image.-->
+## Quick Links
+
+- [Getting Started](docs/getting-started.md) — install and first usage
+- [Introduction](docs/introduction.md) — what the library solves and why
+- [API Reference](https://chris-wolfgang.github.io/IComparable-Extensions/versions/latest/api/Wolfgang.Extensions.IComparable.html) — complete API
+- [GitHub Repository](https://github.com/Chris-Wolfgang/IComparable-Extensions) — source code
+
+## About Wolfgang.Extensions.IComparable
+
+Extension methods for `IComparable<T>` that make ordering and range checks read the way you'd say them — `value.IsBetween(low, high)` instead of `value.CompareTo(low) > 0 && value.CompareTo(high) < 0`.
+
+## Installation
+
+```bash
+dotnet add package Wolfgang.Extensions.IComparable
+```
+
+## Documentation Sections
+
+### 📖 [Getting Started](docs/getting-started.md)
+Step-by-step instructions for installing the package and using `IsBetween` / `IsInRange` in your project.
+
+### 📚 [API Reference](https://chris-wolfgang.github.io/IComparable-Extensions/versions/latest/api/Wolfgang.Extensions.IComparable.html)
+Complete API documentation automatically generated from source XML comments.
+
+## Additional Resources
+
+- [Contributing Guidelines](https://github.com/Chris-Wolfgang/IComparable-Extensions/blob/main/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/Chris-Wolfgang/IComparable-Extensions/blob/main/CODE_OF_CONDUCT.md)
+- [License](https://github.com/Chris-Wolfgang/IComparable-Extensions/blob/main/LICENSE)
+
+---
+
+*Documentation built with [DocFX](https://dotnet.github.io/docfx/)*

--- a/docfx_project/index.md
+++ b/docfx_project/index.md
@@ -10,7 +10,7 @@ Welcome to the Wolfgang.Extensions.IComparable documentation. This site contains
 
 - [Getting Started](docs/getting-started.md) — install and first usage
 - [Introduction](docs/introduction.md) — what the library solves and why
-- [API Reference](https://chris-wolfgang.github.io/IComparable-Extensions/versions/latest/api/Wolfgang.Extensions.IComparable.html) — complete API
+- [API Reference](api/Wolfgang.Extensions.IComparable.html) — complete API
 - [GitHub Repository](https://github.com/Chris-Wolfgang/IComparable-Extensions) — source code
 
 ## About Wolfgang.Extensions.IComparable
@@ -28,7 +28,7 @@ dotnet add package Wolfgang.Extensions.IComparable
 ### 📖 [Getting Started](docs/getting-started.md)
 Step-by-step instructions for installing the package and using `IsBetween` / `IsInRange` in your project.
 
-### 📚 [API Reference](https://chris-wolfgang.github.io/IComparable-Extensions/versions/latest/api/Wolfgang.Extensions.IComparable.html)
+### 📚 [API Reference](api/Wolfgang.Extensions.IComparable.html)
 Complete API documentation automatically generated from source XML comments.
 
 ## Additional Resources

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -119,7 +119,7 @@ reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" \
 
 ```bash
 # Run only unit tests
-dotnet test tests/Wolfgang.Extensions.IComparable.Tests/Wolfgang.Extensions.IComparable.Tests.csproj
+dotnet test tests/Wolfgang.Extensions.IComparable.Tests.Unit/Wolfgang.Extensions.IComparable.Tests.Unit.csproj
 ```
 
 ## Code Quality Checks
@@ -168,8 +168,8 @@ IComparable-Extensions/
 │       ├── Wolfgang.Extensions.IComparable.csproj
 │       └── IComparableExtensions.cs
 ├── tests/
-│   └── Wolfgang.Extensions.IComparable.Tests/
-│       ├── Wolfgang.Extensions.IComparable.Tests.csproj
+│   └── Wolfgang.Extensions.IComparable.Tests.Unit/
+│       ├── Wolfgang.Extensions.IComparable.Tests.Unit.csproj
 │       └── IComparableExtensionsTests.cs
 ├── benchmarks/
 │   └── (Benchmark projects)


### PR DESCRIPTION
## Summary

D5 audit of all markdown files except `README.md` (separate D2 PR
#131). Two drift items fixed.

## Fixed

### `docfx_project/index.md`
The DocFX landing page was the unfilled template:

```markdown
# Title

## Quick Start Notes:

<!--1. Add images to the *images* folder if the file is referencing an image.-->
```

Rewritten using the DateTime-Extensions canonical landing-page shape
— real title, about paragraph linking to the source repo, Quick Links,
Installation block with `dotnet add package`, Documentation Sections
linking to the two docs/ subpages and the auto-generated API
reference, plus Contributing/Code-of-Conduct/License links.

### `docs/setup.md`
Three references to the test project used the wrong name:

```
tests/Wolfgang.Extensions.IComparable.Tests/Wolfgang.Extensions.IComparable.Tests.csproj
```

The actual project on disk is `Wolfgang.Extensions.IComparable.Tests.Unit`. Fixed all three occurrences (the `dotnet test` command on L122, plus the source-tree diagram on L171-172).

## Other markdown read and found accurate

- `CHANGELOG.md`
- `CONTRIBUTING.md`
- `CODE_OF_CONDUCT.md`
- `SECURITY.md`
- `.github/copilot-instructions.md`
- `.github/pull_request_template.md`
- `docs/introduction.md`
- `docs/getting-started.md`
- `docs/README-FORMATTING.md`
- `docs/RELEASE-WORKFLOW-SETUP.md`
- `docs/WORKFLOW_SECURITY.md`
- `docs/DOCFX-VERSION-PICKER.md`

Stacked on vNext (PR #129).