### PR TITLE
C5: dedent test class to match file-scoped namespace convention (closes #92, #93)

### DIFF
--- a/tests/Wolfgang.Extensions.IComparable.Tests.Unit/IComparableExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.IComparable.Tests.Unit/IComparableExtensionsTests.cs
@@ -2,189 +2,189 @@ using System.Globalization;
 
 namespace Wolfgang.Extensions.IComparable.Tests.Unit;
 
-    // ReSharper disable once InconsistentNaming
-    public class IComparableExtensionsTests
+// ReSharper disable once InconsistentNaming
+public class IComparableExtensionsTests
+{
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, false)]
+    [InlineData(5, true)]
+    [InlineData(10, false)]
+    [InlineData(11, false)]
+    public void IsBetween_when_called_on_integers_returns_expected_result(int value, bool expectedValue)
     {
-
-        [Theory]
-        [InlineData(0, false)]
-        [InlineData(1, false)]
-        [InlineData(5, true)]
-        [InlineData(10, false)]
-        [InlineData(11, false)]
-        public void IsBetween_when_called_on_integers_returns_expected_result(int value, bool expectedValue)
-        {
-            Assert.Equal(expectedValue, value.IsBetween(1, 10));
-        }
-
-
-
-        [Theory]
-        [InlineData("2010/12/31 23:59:59", false)]
-        [InlineData("2011/1/1", false)]
-        [InlineData("2011/7/1", true)]
-        [InlineData("2011/12/31 23:59:59", false)]
-        [InlineData("2012/1/1", false)]
-        public void IsBetween_when_called_on_date_times_returns_expected_result(string value, bool expectedValue)
-        {
-            var testValue = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
-            Assert.Equal(expectedValue, testValue.IsBetween(new DateTime(2011, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2011, 12, 31, 23, 59, 59, DateTimeKind.Utc)));
-        }
-
-
-
-        [Theory]
-        [InlineData("2018/11/2", false)]
-        [InlineData("2018/11/4", true)]
-        [InlineData("2018/11/6", false)]
-        public void IsBetween_when_called_on_specific_dates_returns_expected_result(DateTime value, bool expectedValue)
-        {
-            var utcValue = DateTime.SpecifyKind(value, DateTimeKind.Utc);
-            Assert.Equal(expectedValue, utcValue.IsBetween(new DateTime(2018, 11, 2, 0, 0, 0, DateTimeKind.Utc), new DateTime(2018, 11, 6, 0, 0, 0, DateTimeKind.Utc)));
-        }
-
-
-
-        [Theory]
-        [InlineData("aa", false)]
-        [InlineData("ab", false)]
-        [InlineData("am", true)]
-        [InlineData("ay", false)]
-        [InlineData("az", false)]
-        public void IsBetween_when_called_on_strings_returns_expected_result(string value, bool expectedValue)
-        {
-            Assert.Equal(expectedValue, value.IsBetween("ab", "ay"));
-        }
-
-
-
-        [Theory]
-        [InlineData('a', false)]
-        [InlineData('b', false)]
-        [InlineData('m', true)]
-        [InlineData('y', false)]
-        [InlineData('z', false)]
-        public void IsBetween_when_called_on_chars_returns_expected_result(char value, bool expectedValue)
-        {
-            Assert.Equal(expectedValue, value.IsBetween('b', 'y'));
-        }
-
-
-
-        [Fact]
-        public void IsBetween_when_value_equals_both_bounds_returns_false()
-        {
-            Assert.False(5.IsBetween(5, 5));
-        }
-
-
-
-        [Fact]
-        public void IsBetween_when_bounds_are_inverted_returns_false()
-        {
-            Assert.False(5.IsBetween(10, 1));
-        }
-
-
-
-        [Fact]
-        public void IsBetween_when_value_is_null_throws_argument_null_exception()
-        {
-            string? value = null;
-
-            Assert.Throws<ArgumentNullException>(() => value!.IsBetween("a", "z"));
-        }
-
-
-
-        [Theory]
-        [InlineData(0, false)]
-        [InlineData(1, true)]
-        [InlineData(5, true)]
-        [InlineData(10, true)]
-        [InlineData(11, false)]
-        public void IsInRange_when_called_on_integers_returns_expected_result(int value, bool expectedValue)
-        {
-            Assert.Equal(expectedValue, value.IsInRange(1, 10));
-        }
-
-
-
-        [Theory]
-        [InlineData("2010/12/31 23:59:59", false)]
-        [InlineData("2011/1/1", true)]
-        [InlineData("2011/7/1", true)]
-        [InlineData("2011/12/31 23:59:50", true)]
-        [InlineData("2012/1/1", false)]
-        public void IsInRange_when_called_on_date_times_returns_expected_result(string value, bool expectedValue)
-        {
-            var testValue = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
-            Assert.Equal(expectedValue, testValue.IsInRange(new DateTime(2011, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2011, 12, 31, 23, 59, 59, DateTimeKind.Utc)));
-        }
-
-
-
-        [Theory]
-        [InlineData("2018/11/1", false)]
-        [InlineData("2018/11/2", true)]
-        [InlineData("2018/11/4", true)]
-        [InlineData("2018/11/6", true)]
-        [InlineData("2018/11/7", false)]
-        public void IsInRange_when_called_on_specific_dates_returns_expected_result(DateTime value, bool expectedValue)
-        {
-            var utcValue = DateTime.SpecifyKind(value, DateTimeKind.Utc);
-            Assert.Equal(expectedValue, utcValue.IsInRange(new DateTime(2018, 11, 2, 0, 0, 0, DateTimeKind.Utc), new DateTime(2018, 11, 6, 0, 0, 0, DateTimeKind.Utc)));
-        }
-
-
-
-        [Theory]
-        [InlineData("a", false)]
-        [InlineData("b", true)]
-        [InlineData("m", true)]
-        [InlineData("y", true)]
-        [InlineData("z", false)]
-        public void IsInRange_when_called_on_strings_returns_expected_result(string value, bool expectedValue)
-        {
-            Assert.Equal(expectedValue, value.IsInRange("b", "y"));
-        }
-
-
-
-        [Theory]
-        [InlineData('a', false)]
-        [InlineData('b', true)]
-        [InlineData('m', true)]
-        [InlineData('y', true)]
-        [InlineData('z', false)]
-        public void IsInRange_when_called_on_chars_returns_expected_result(char value, bool expectedValue)
-        {
-            Assert.Equal(expectedValue, value.IsInRange('b', 'y'));
-        }
-
-
-
-        [Fact]
-        public void IsInRange_when_value_equals_both_bounds_returns_true()
-        {
-            Assert.True(5.IsInRange(5, 5));
-        }
-
-
-
-        [Fact]
-        public void IsInRange_when_bounds_are_inverted_returns_false()
-        {
-            Assert.False(5.IsInRange(10, 1));
-        }
-
-
-
-        [Fact]
-        public void IsInRange_when_value_is_null_throws_argument_null_exception()
-        {
-            string? value = null;
-
-            Assert.Throws<ArgumentNullException>(() => value!.IsInRange("a", "z"));
-        }
+        Assert.Equal(expectedValue, value.IsBetween(1, 10));
     }
+
+
+
+    [Theory]
+    [InlineData("2010/12/31 23:59:59", false)]
+    [InlineData("2011/1/1", false)]
+    [InlineData("2011/7/1", true)]
+    [InlineData("2011/12/31 23:59:59", false)]
+    [InlineData("2012/1/1", false)]
+    public void IsBetween_when_called_on_date_times_returns_expected_result(string value, bool expectedValue)
+    {
+        var testValue = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+        Assert.Equal(expectedValue, testValue.IsBetween(new DateTime(2011, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2011, 12, 31, 23, 59, 59, DateTimeKind.Utc)));
+    }
+
+
+
+    [Theory]
+    [InlineData("2018/11/2", false)]
+    [InlineData("2018/11/4", true)]
+    [InlineData("2018/11/6", false)]
+    public void IsBetween_when_called_on_specific_dates_returns_expected_result(DateTime value, bool expectedValue)
+    {
+        var utcValue = DateTime.SpecifyKind(value, DateTimeKind.Utc);
+        Assert.Equal(expectedValue, utcValue.IsBetween(new DateTime(2018, 11, 2, 0, 0, 0, DateTimeKind.Utc), new DateTime(2018, 11, 6, 0, 0, 0, DateTimeKind.Utc)));
+    }
+
+
+
+    [Theory]
+    [InlineData("aa", false)]
+    [InlineData("ab", false)]
+    [InlineData("am", true)]
+    [InlineData("ay", false)]
+    [InlineData("az", false)]
+    public void IsBetween_when_called_on_strings_returns_expected_result(string value, bool expectedValue)
+    {
+        Assert.Equal(expectedValue, value.IsBetween("ab", "ay"));
+    }
+
+
+
+    [Theory]
+    [InlineData('a', false)]
+    [InlineData('b', false)]
+    [InlineData('m', true)]
+    [InlineData('y', false)]
+    [InlineData('z', false)]
+    public void IsBetween_when_called_on_chars_returns_expected_result(char value, bool expectedValue)
+    {
+        Assert.Equal(expectedValue, value.IsBetween('b', 'y'));
+    }
+
+
+
+    [Fact]
+    public void IsBetween_when_value_equals_both_bounds_returns_false()
+    {
+        Assert.False(5.IsBetween(5, 5));
+    }
+
+
+
+    [Fact]
+    public void IsBetween_when_bounds_are_inverted_returns_false()
+    {
+        Assert.False(5.IsBetween(10, 1));
+    }
+
+
+
+    [Fact]
+    public void IsBetween_when_value_is_null_throws_argument_null_exception()
+    {
+        string? value = null;
+
+        Assert.Throws<ArgumentNullException>(() => value!.IsBetween("a", "z"));
+    }
+
+
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(5, true)]
+    [InlineData(10, true)]
+    [InlineData(11, false)]
+    public void IsInRange_when_called_on_integers_returns_expected_result(int value, bool expectedValue)
+    {
+        Assert.Equal(expectedValue, value.IsInRange(1, 10));
+    }
+
+
+
+    [Theory]
+    [InlineData("2010/12/31 23:59:59", false)]
+    [InlineData("2011/1/1", true)]
+    [InlineData("2011/7/1", true)]
+    [InlineData("2011/12/31 23:59:50", true)]
+    [InlineData("2012/1/1", false)]
+    public void IsInRange_when_called_on_date_times_returns_expected_result(string value, bool expectedValue)
+    {
+        var testValue = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+        Assert.Equal(expectedValue, testValue.IsInRange(new DateTime(2011, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2011, 12, 31, 23, 59, 59, DateTimeKind.Utc)));
+    }
+
+
+
+    [Theory]
+    [InlineData("2018/11/1", false)]
+    [InlineData("2018/11/2", true)]
+    [InlineData("2018/11/4", true)]
+    [InlineData("2018/11/6", true)]
+    [InlineData("2018/11/7", false)]
+    public void IsInRange_when_called_on_specific_dates_returns_expected_result(DateTime value, bool expectedValue)
+    {
+        var utcValue = DateTime.SpecifyKind(value, DateTimeKind.Utc);
+        Assert.Equal(expectedValue, utcValue.IsInRange(new DateTime(2018, 11, 2, 0, 0, 0, DateTimeKind.Utc), new DateTime(2018, 11, 6, 0, 0, 0, DateTimeKind.Utc)));
+    }
+
+
+
+    [Theory]
+    [InlineData("a", false)]
+    [InlineData("b", true)]
+    [InlineData("m", true)]
+    [InlineData("y", true)]
+    [InlineData("z", false)]
+    public void IsInRange_when_called_on_strings_returns_expected_result(string value, bool expectedValue)
+    {
+        Assert.Equal(expectedValue, value.IsInRange("b", "y"));
+    }
+
+
+
+    [Theory]
+    [InlineData('a', false)]
+    [InlineData('b', true)]
+    [InlineData('m', true)]
+    [InlineData('y', true)]
+    [InlineData('z', false)]
+    public void IsInRange_when_called_on_chars_returns_expected_result(char value, bool expectedValue)
+    {
+        Assert.Equal(expectedValue, value.IsInRange('b', 'y'));
+    }
+
+
+
+    [Fact]
+    public void IsInRange_when_value_equals_both_bounds_returns_true()
+    {
+        Assert.True(5.IsInRange(5, 5));
+    }
+
+
+
+    [Fact]
+    public void IsInRange_when_bounds_are_inverted_returns_false()
+    {
+        Assert.False(5.IsInRange(10, 1));
+    }
+
+
+
+    [Fact]
+    public void IsInRange_when_value_is_null_throws_argument_null_exception()
+    {
+        string? value = null;
+
+        Assert.Throws<ArgumentNullException>(() => value!.IsInRange("a", "z"));
+    }
+}


### PR DESCRIPTION
## Summary

Code-review (C5) pass on IComparable-Extensions, plus the dead-code
sweep (#93). Whitespace-only fix this PR; the rest of the audit had
no findings worth a change.

## What changed

`tests/Wolfgang.Extensions.IComparable.Tests.Unit/IComparableExtensionsTests.cs`
— class + members dedented by 4 spaces. The file uses a file-scoped
namespace (`namespace X;`) but the class kept block-namespace
indentation. The fix is pure whitespace.

## Audit findings

### Source (`src/.../IComparableExtensions.cs`, 74 LOC) — clean

- Both public methods (`IsBetween<T>`, `IsInRange<T>`) have complete
  XML docs with `<summary>`, `<param>`, `<returns>`, `<exception>`
- Both correctly throw `ArgumentNullException(nameof(value))` when
  `value` is `null`
- Multi-line argument lists follow CLAUDE.md's Allman style (opening
  paren on its own line, each arg indented, closing paren on its own
  line)
- File-scoped namespace
- 3 blank lines between members
- No `async`, no allocations in tight loops, no string concat, no
  LINQ chains — there's nothing tight to optimize in a CompareTo
  wrapper

### Tests (190 LOC) — clean apart from indentation

- All 16 tests assert
- All follow the `MethodName_when_condition_expected_result` naming
- Cover the boundary matrix: lower-edge, upper-edge, mid-range,
  outside-low, outside-high, equal-bounds, inverted-bounds, null-value
- Cover four `T` shapes: `int`, `DateTime`, `string`, `char`
- No private helpers, no dead test code

### Dead code (#93)

- `src/` has 2 public methods, both used by tests — no dead surface
- `tests/` has 16 public `[Fact]`/`[Theory]` methods, no private
  helpers, no unused symbols
- `examples/` has two `Program.Main` methods (net462 + net8) — both
  the entry points, neither dead

Closing #93 as "no dead code found" via this PR's Closes line.

## Possible future work (out of scope for this PR)

- Document and test behavior when `lowerBound` or `upperBound` is
  `null` — current code defers to `T`'s `CompareTo` contract
  (`string.CompareTo(null)` returns positive, so `IsBetween(null, "z")`
  is `true`). Worth a follow-up issue if you want that contract
  formalized.
- Add a custom-`IComparable<T>` test (e.g. a `Money` record) — the
  README rewrite in #131 shows this usage, but no test exists.
  Low priority since `int`/`DateTime`/`string`/`char` already exercise
  generic dispatch.

Stacked on vNext (PR #129).