### PR TITLE
T4 follow-up: negative-int + MinValue/MaxValue edge cases

### DIFF
--- a/tests/Wolfgang.Extensions.IComparable.Tests.Unit/IComparableExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.IComparable.Tests.Unit/IComparableExtensionsTests.cs
@@ -283,4 +283,73 @@ public class IComparableExtensionsTests
         // "m".CompareTo(null) <= 0 → 1 <= 0 → false.
         Assert.False("m".IsInRange("a", null!));
     }
+
+
+
+    // ---------------------------------------------------------------
+    // Edge-case integer coverage — negative bounds + value-type
+    // extremes. The behaviour is the same as the positive cases by
+    // construction, but these rows lock in that the implementation
+    // doesn't accidentally specialise on positive numbers (e.g. via
+    // an unsigned compare or an `Abs`-based shortcut introduced
+    // during a future refactor).
+    // ---------------------------------------------------------------
+
+    [Theory]
+    [InlineData(-11, false)]   // below the negative-to-zero range
+    [InlineData(-10, false)]   // exact lower (strict)
+    [InlineData(-5, true)]     // mid
+    [InlineData(0, false)]     // exact upper (strict)
+    [InlineData(1, false)]     // above
+    public void IsBetween_when_called_on_negative_integer_range_returns_expected_result(int value, bool expectedValue)
+    {
+        Assert.Equal(expectedValue, value.IsBetween(-10, 0));
+    }
+
+
+
+    [Theory]
+    [InlineData(-11, false)]   // below
+    [InlineData(-10, true)]    // exact lower (inclusive)
+    [InlineData(-5, true)]     // mid
+    [InlineData(0, true)]      // exact upper (inclusive)
+    [InlineData(1, false)]     // above
+    public void IsInRange_when_called_on_negative_integer_range_returns_expected_result(int value, bool expectedValue)
+    {
+        Assert.Equal(expectedValue, value.IsInRange(-10, 0));
+    }
+
+
+
+    [Fact]
+    public void IsBetween_when_value_equals_int_MaxValue_against_full_range_returns_false()
+    {
+        // strict upper — MaxValue is NOT > MaxValue
+        Assert.False(int.MaxValue.IsBetween(int.MinValue, int.MaxValue));
+    }
+
+
+
+    [Fact]
+    public void IsBetween_when_value_equals_int_MinValue_against_full_range_returns_false()
+    {
+        // strict lower — MinValue is NOT < MinValue
+        Assert.False(int.MinValue.IsBetween(int.MinValue, int.MaxValue));
+    }
+
+
+
+    [Fact]
+    public void IsInRange_when_value_equals_int_MaxValue_against_full_range_returns_true()
+    {
+        Assert.True(int.MaxValue.IsInRange(int.MinValue, int.MaxValue));
+    }
+
+
+
+    [Fact]
+    public void IsInRange_when_value_equals_int_MinValue_against_full_range_returns_true()
+    {
+        Assert.True(int.MinValue.IsInRange(int.MinValue, int.MaxValue));
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #134 (T4 test-quality audit). Closes the smaller
edge-case gaps the audit noted but skipped at the time — the bulk
(custom `IComparable<T>` + null-bound contracts) landed in #134;
this PR is purely additive coverage.

## Stacked on #134

Base = `stack/t4-test-quality-audit`. When #134 merges, this PR's
base auto-promotes to `vNext`.

## What this adds

### 1. Negative integer range Theories (10 rows)

Every existing int Theory used positive bounds (1, 10). Added a
parallel Theory with bounds (-10, 0) covering below, exact-lower,
mid, exact-upper, above for both methods. By construction these
exercise the same code path as the positive cases, but a future
refactor introducing an `Abs`-based shortcut or an unsigned compare
would now break loudly.

### 2. `int.MinValue` / `int.MaxValue` boundary Facts (4)

Four Facts covering `value = int.MaxValue` and `value = int.MinValue`
against `(int.MinValue, int.MaxValue)` bounds for both methods.
Confirms strict bounds reject the exact extremes (`IsBetween → false`)
and inclusive bounds accept them (`IsInRange → true`).

### 3. `Money` record documentation (comment only)

The `Money` fixture introduced in #134 stipulates that
`CompareTo(null)` returns +1 (null is the smallest value). That's a
valid convention per IComparable<T> guidance but the choice was
hidden in the record definition. Added a comment explaining the
rationale.

## Skipped from the audit notes — not worth adding

- **Inverted bounds for non-int types** (gap #1 from the followup
  list): behaviour is type-agnostic, adding string/DateTime/char rows
  would be padding.
- **Equal-bounds for non-int types** (#2): same reason.
- **String edge cases (`""`, very long strings)** (#5): lexicographic
  comparison is well-defined; gain is small.
- **Redundant DateTime Theory** (#6): both the string-typed parser
  and the typed-DateTime variant exercise the same behaviour; removing
  either loses nothing but adds churn.
- **Double-CompareTo invocation testability** (#8): not testable
  without a mock, not a real risk.

## Verified

```
$ dotnet test ... -c Release --framework net10.0
Passed!  Failed: 0, Passed: 72, Skipped: 0, Total: 72
```

72 cases — 58 after #134 + 10 negative-int rows + 4 MinValue/MaxValue
Facts.