### PR TITLE
T3: stryker-config.json — enables Stryker.NET mutation testing (100% baseline)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -431,3 +431,6 @@ nuget-packages/
 docfx_project/_site/
 docfx_project/obj/
 
+
+# Stryker.NET mutation testing report output
+StrykerOutput/

--- a/stryker-config.json
+++ b/stryker-config.json
@@ -1,0 +1,19 @@
+{
+  "stryker-config": {
+    "project": "src/Wolfgang.Extensions.IComparable/Wolfgang.Extensions.IComparable.csproj",
+    "test-projects": [
+      "tests/Wolfgang.Extensions.IComparable.Tests.Unit/Wolfgang.Extensions.IComparable.Tests.Unit.csproj"
+    ],
+    "target-framework": "net10.0",
+    "reporters": [
+      "html",
+      "json",
+      "progress"
+    ],
+    "thresholds": {
+      "high": 90,
+      "low": 75,
+      "break": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `stryker-config.json` at the repo root so the canonical
`stryker.yaml` workflow (already shipped via the T3 fanout) actually
runs mutation testing against this repo. Locally verified: **100%
mutation score** on the v1.1.1 test surface.

## Why this PR was needed

The canonical `stryker.yaml` workflow has been on
`canonical-protected` since the T3 fanout, but its Detect step
exits as a no-op when no `stryker-config.json` is found. That made
the workflow infrastructure-only — never producing a mutation
score for any repo.

This PR ships the per-repo config that turns the workflow on.

## Config

```json
{
  "stryker-config": {
    "project": "Wolfgang.Extensions.IComparable.csproj",
    "test-projects": [
      "tests/Wolfgang.Extensions.IComparable.Tests.Unit/Wolfgang.Extensions.IComparable.Tests.Unit.csproj"
    ],
    "target-framework": "net10.0",
    "reporters": ["html", "json", "progress"],
    "thresholds": { "high": 90, "low": 75, "break": 0 }
  }
}
```

Notes:
- **`target-framework: net10.0`** — Stryker mutates one TFM at a
  time; net10.0 is the modern target. The test project still
  multi-targets net462 → net10.0 for ordinary `dotnet test`.
- **`thresholds.break: 0`** — keeps CI runs green while a baseline
  is being established. Raise to a real number after a few runs
  confirm the score is stable.
- **No `mutate` glob** — Stryker's default (mutate every `*.cs` in
  the project's directory) is what we want. An explicit
  workspace-rooted glob actually *excluded* every mutant on the
  first attempt because Stryker resolves `mutate` paths relative to
  the .csproj, not the repo root.

## Local run results

```
[INF] 18 mutants created
[INF]  4 mutants got status Ignored (block already covered)
[INF] 14 mutants tested
Killed:   14
Survived:  0
Timeout:   0
Final mutation score: 100.00 %
```

100% on the 14 mutants Stryker chose to test (the rest were
redundantly covered). For a 2-method comparison library with the
test surface this stack puts in place (PRs #131-#135), this is the
expected outcome — every comparison-operator mutation,
boundary-value mutation, and exception-throw mutation has a test
that observes the difference.

## Bug found and fixed (folded into PR #134)

Stryker's first attempt failed to build because the `Money` record
introduced in #134 uses `init` setters, which require
`System.Runtime.CompilerServices.IsExternalInit` — missing on
net462/net47x/net48x. The fix (replace the record with a sealed
class) was folded into #134 via `--amend` + force-push (#135 was
rebased onto the amended #134).

This is the kind of bug the canonical pr.yaml's multi-TFM Stage 2
Windows job would normally catch, but pr.yaml only runs against
PRs targeting `main` — stacked PRs against vNext don't trigger it.
Calling out as a follow-up: it would be worth extending pr.yaml's
trigger to also fire on PRs targeting `vNext`, or running a
multi-TFM smoke build locally before stacking on vNext in future
pilots.

## Reporting

Stryker writes HTML + JSON reports to `StrykerOutput/<timestamp>/`
on each run. Added a `.gitignore` entry for that directory so
reports don't get committed by accident.

Stacked on top of PR #135 (edge-case coverage); base auto-promotes
through #134 → #135 → vNext as each merges.