### PR TITLE
Code review C: documentation drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,3 +74,8 @@ runtime behavior change vs v1.1.0.
   consumers without a binding redirect. (See DateTime-Extensions v1.3.1
   for the post-mortem on what happens when this regression reaches a
   release.)
+
+[Unreleased]: https://github.com/Chris-Wolfgang/IComparable-Extensions/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/Chris-Wolfgang/IComparable-Extensions/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/Chris-Wolfgang/IComparable-Extensions/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/Chris-Wolfgang/IComparable-Extensions/releases/tag/v1.0.0

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,10 @@ This guide will help you quickly start using Wolfgang.Extensions.IComparable in 
 
 ## Prerequisites
 
-- .NET 8.0 or later
+- Any .NET runtime that supports **.NET Standard 2.0** or later. That includes:
+  - .NET Framework 4.6.2 and later
+  - .NET Core 2.0 and later
+  - .NET 5, 6, 7, 8, 9, and 10
 - A C# project (any project type: console, web, library, etc.)
 
 ## Installation


### PR DESCRIPTION
Two doc fixes from the v1.1.1 code review:

1. `docs/getting-started.md` prereq said .NET 8.0 only; library actually targets net462 → net10.0. Rewrote to spell out the runtime matrix.
2. `CHANGELOG.md` was missing the Keep-a-Changelog footer compare-links. Added.

Doc-only. Stacked on vNext (PR #129).