### PR TITLE
Code review D: A1 PublicAPI baseline

### DIFF
--- a/src/Wolfgang.Extensions.IComparable/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Extensions.IComparable/PublicAPI.Shipped.txt
@@ -1,0 +1,4 @@
+#nullable enable
+static Wolfgang.Extensions.IComparable.IComparableExtensions.IsBetween<T>(this T value, T lowerBound, T upperBound) -> bool
+static Wolfgang.Extensions.IComparable.IComparableExtensions.IsInRange<T>(this T value, T lowerBound, T upperBound) -> bool
+Wolfgang.Extensions.IComparable.IComparableExtensions

--- a/src/Wolfgang.Extensions.IComparable/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Extensions.IComparable/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable


### PR DESCRIPTION
Turns on `Microsoft.CodeAnalysis.PublicApiAnalyzers` for this repo by adding the `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` files alongside the src csproj.

Shipped lists the two public extension methods + the containing static class — the v1.1.0 baseline. Unshipped is empty since no surface changes are queued.

After this merges, accidentally changing the public surface (rename, new method, removed method) will fail the Release build with RS0016/RS0017 instead of silently shipping.

Verified: `dotnet build -c Release` is clean, 0 warnings, 0 errors. Stacked on vNext (PR #129).