### PR TITLE
Code review E: examples polish

### DIFF
--- a/examples/Wolfgang.Extensions.IComparable.DotNet462.Example1/Program.cs
+++ b/examples/Wolfgang.Extensions.IComparable.DotNet462.Example1/Program.cs
@@ -8,31 +8,19 @@ namespace Wolfgang.Extensions.IComparable.DotNet462.Example1
         {
             Console.ForegroundColor = ConsoleColor.White;
 
-            var value = 1;
-            Console.WriteLine("   " + value + " IsBetween 1 and 10: " + value.IsBetween(1, 10));
+            int[] values = { 1, 2, 9, 10 };
 
-            value = 2;
-            Console.WriteLine("   " + value + " IsBetween 1 and 10: " + value.IsBetween(1, 10));
-
-            value = 9;
-            Console.WriteLine("   " + value + " IsBetween 1 and 10: " + value.IsBetween(1, 10));
-
-            value = 10;
-            Console.WriteLine("  " + value + " IsBetween 1 and 10: " + value.IsBetween(1, 10));
+            foreach (var value in values)
+            {
+                Console.WriteLine($"   {value,2} IsBetween 1 and 10: {value.IsBetween(1, 10)}");
+            }
 
             Console.WriteLine();
 
-            value = 1;
-            Console.WriteLine("   " + value + " IsInRange 1 and 10: " + value.IsInRange(1, 10));
-
-            value = 2;
-            Console.WriteLine("   " + value + " IsInRange 1 and 10: " + value.IsInRange(1, 10));
-
-            value = 9;
-            Console.WriteLine("   " + value + " IsInRange 1 and 10: " + value.IsInRange(1, 10));
-
-            value = 10;
-            Console.WriteLine("  " + value + " IsInRange 1 and 10: " + value.IsInRange(1, 10));
+            foreach (var value in values)
+            {
+                Console.WriteLine($"   {value,2} IsInRange 1 and 10: {value.IsInRange(1, 10)}");
+            }
 
             Console.WriteLine();
 

--- a/examples/Wolfgang.Extensions.IComparable.DotNet8.Example1/Program.cs
+++ b/examples/Wolfgang.Extensions.IComparable.DotNet8.Example1/Program.cs
@@ -1,41 +1,26 @@
-// See https://aka.ms/new-console-template for more information
-
 namespace Wolfgang.Extensions.IComparable.DotNet8.Example1;
 
 internal static class Program
 {
     public static void Main()
     {
-        
         Console.ForegroundColor = ConsoleColor.White;
 
-        var value = 1;
-        Console.WriteLine($"   {value} IsBetween 1 and 10: {value.IsBetween(1, 10)}");
+        int[] values = [1, 2, 9, 10];
 
-        value = 2;
-        Console.WriteLine($"   {value} IsBetween 1 and 10: {value.IsBetween(1, 10)}");
+        foreach (var value in values)
+        {
+            Console.WriteLine($"   {value,2} IsBetween 1 and 10: {value.IsBetween(1, 10)}");
+        }
 
-        value = 9;
-        Console.WriteLine($"   {value} IsBetween 1 and 10: {value.IsBetween(1, 10)}");
+        Console.WriteLine();
 
-        value = 10;
-        Console.WriteLine($"  {value} IsBetween 1 and 10: {value.IsBetween(1, 10)}");
+        foreach (var value in values)
+        {
+            Console.WriteLine($"   {value,2} IsInRange 1 and 10: {value.IsInRange(1, 10)}");
+        }
 
-        Console.WriteLine("\n");
-
-        value = 1;
-        Console.WriteLine($"   {value} IsInRange 1 and 10: {value.IsInRange(1, 10)}");
-
-        value = 2;
-        Console.WriteLine($"   {value} IsInRange 1 and 10: {value.IsInRange(1, 10)}");
-
-        value = 9;
-        Console.WriteLine($"   {value} IsInRange 1 and 10: {value.IsInRange(1, 10)}");
-
-        value = 10;
-        Console.WriteLine($"  {value} IsInRange 1 and 10: {value.IsInRange(1, 10)}");
-
-        Console.WriteLine("\n");
+        Console.WriteLine();
 
         Console.ResetColor();
     }


### PR DESCRIPTION
Collapses 8 near-duplicate WriteLine blocks per example file to a 4-element `int[]` + two `foreach` loops. Also fixes inconsistent column padding (manual spaces → format alignment), switches the net462 example from `+` string concat to interpolation (C# 6, supported on net462 since 2015), and cleans up a stray blank line + double-newline in the net8 example.

Pure example polish — no library changes. Both example projects build clean in Release.

Stacked on vNext (PR #129).