### PR TITLE
dependabot.yml: drop the retired 'dotnet' label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "dotnet"
 
   - package-ecosystem: "nuget"
     directory: "/src"
@@ -16,7 +15,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "dotnet"
 
   - package-ecosystem: "nuget"
     directory: "/tests"
@@ -25,7 +23,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "dotnet"
 
   - package-ecosystem: "nuget"
     directory: "/benchmarks"
@@ -34,7 +31,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "dotnet"
 
   - package-ecosystem: "nuget"
     directory: "/examples"
@@ -43,4 +39,3 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "dotnet"


### PR DESCRIPTION
Dependabot is failing every run with `The following labels could not be found: dotnet. Please create it before Dependabot can add it to a pull request.` because main's dependabot.yml still lists the fleet-retired `dotnet` label on every nuget entry.

vNext already has this fix — when PR #129 merges, this PR's diff will collapse to a no-op (the only remaining delta is the `/benchmarks` entry that #137 also drops). Landing here directly so Dependabot can keep opening PRs in the meantime.

Touches only `.github/dependabot.yml` (not a workflow path, not protected). Should merge without admin-bypass.