### PR TITLE
Directory.Build.props analyzer bumps (admin-bypass)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,13 +53,13 @@
     </PackageReference>
     
     <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.85">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.98">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.25.0.139117">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Tiny follow-up to PR #146. The protected baseline shipped with Meziantou 3.0.85 / SonarAnalyzer 10.25.0 because canonical-protected had not yet been folded into vNext at extract time. After the canonical-protected → vNext fold, vNext has the newer Meziantou 3.0.98 / SonarAnalyzer 10.27.0 — this PR brings main up to match.

| Package | main today | vNext |
|---|---|---|
| Meziantou.Analyzer | 3.0.85 | 3.0.98 |
| SonarAnalyzer.CSharp | 10.25.0.139117 | 10.27.0.140913 |

Touches only `Directory.Build.props` — protected, so admin-bypass at merge. After merge → I'll fold main back into vNext → PR #129 flips to fully clean.