### PR TITLE
version-picker-template.html: sync to canonical (auto-redirect)

### DIFF
--- a/.github/version-picker-template.html
+++ b/.github/version-picker-template.html
@@ -4,6 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{TITLE}}</title>
+
+  <!-- Auto-redirect to the latest version of the docs.
+       The in-page version picker (docfx_project/public/version-picker.js)
+       lets readers switch versions from any page once they land there, so
+       the root no longer needs to be a "pick a version" landing page —
+       a redirect to /versions/latest/ is the desired UX.
+
+       meta-refresh works without JavaScript; the JS fallback below kicks
+       in if the meta-refresh is blocked by some agent. Visible text +
+       <noscript> link covers everything else. -->
+  <meta http-equiv="refresh" content="0; url=versions/latest/">
+  <link rel="canonical" href="versions/latest/">
+
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -12,28 +25,34 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      justify-content: center;
       padding: 3rem 1rem;
       min-height: 100vh;
       margin: 0;
+      text-align: center;
     }
-    h1 { font-size: 2rem; margin-bottom: 0.5rem; color: #cba6f7; }
-    p  { color: #a6adc8; margin-bottom: 2rem; }
-    ul { list-style: none; padding: 0; width: 100%; max-width: 480px; }
-    li a {
-      display: block; padding: 0.75rem 1.25rem; margin-bottom: 0.5rem;
-      border-radius: 6px; background: #313244; color: #89b4fa;
-      text-decoration: none; font-size: 1.05rem; transition: background 0.15s;
-    }
-    li a:hover { background: #45475a; }
-    li.latest a { background: #1e66f5; color: #fff; font-weight: bold; }
-    li.latest a:hover { background: #1959d9; }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; color: #cba6f7; }
+    a  { color: #89b4fa; }
   </style>
+  <script>
+    // Backup redirect in case meta-refresh is suppressed.
+    setTimeout(function () {
+      window.location.replace('versions/latest/');
+    }, 50);
+  </script>
 </head>
 <body>
   <h1>{{TITLE}}</h1>
-  <p>Select a documentation version:</p>
-  <ul>
-{{VERSION_LIST}}
-  </ul>
+  <p>Redirecting to the <a href="versions/latest/">latest documentation</a>&hellip;</p>
+  <noscript>
+    <p>JavaScript is disabled. <a href="versions/latest/">Click here</a> to continue.</p>
+  </noscript>
+  <!-- The docfx.yaml workflow's substitution still looks for {{VERSION_LIST}}
+       but the placeholder is intentionally omitted from this template: a
+       missing pattern is a true no-op for PowerShell's `-replace` (returns
+       the original string unchanged). The in-page <select> dropdown shipped
+       in docfx_project/public/version-picker.js is now the canonical
+       version-selector UI, so no list of links needs to be rendered into
+       the root redirect page. -->
 </body>
 </html>

--- a/.github/version-picker-template.html
+++ b/.github/version-picker-template.html
@@ -9,7 +9,9 @@
        The in-page version picker (docfx_project/public/version-picker.js)
        lets readers switch versions from any page once they land there, so
        the root no longer needs to be a "pick a version" landing page —
-       a redirect to /versions/latest/ is the desired UX.
+       a redirect to `versions/latest/` (relative — a leading slash
+       would break under GitHub Pages project sites at `/<repo>/...`)
+       is the desired UX.
 
        meta-refresh works without JavaScript; the JS fallback below kicks
        in if the meta-refresh is blocked by some agent. Visible text +
@@ -47,12 +49,14 @@
   <noscript>
     <p>JavaScript is disabled. <a href="versions/latest/">Click here</a> to continue.</p>
   </noscript>
-  <!-- The docfx.yaml workflow's substitution still looks for {{VERSION_LIST}}
-       but the placeholder is intentionally omitted from this template: a
-       missing pattern is a true no-op for PowerShell's `-replace` (returns
-       the original string unchanged). The in-page <select> dropdown shipped
-       in docfx_project/public/version-picker.js is now the canonical
-       version-selector UI, so no list of links needs to be rendered into
-       the root redirect page. -->
+  <!-- Both the docfx.yaml and build-all-versions.yaml workflows still
+       run a `-replace` on {{VERSION_LIST}}, but the placeholder is
+       intentionally omitted from this template: a missing pattern is a
+       true no-op for PowerShell's `-replace` (returns the original
+       string unchanged), so the substitution silently does nothing. The
+       in-page <select> dropdown shipped in
+       docfx_project/public/version-picker.js is now the canonical
+       version-selector UI, so no list of links needs to be rendered
+       into the root redirect page. -->
 </body>
 </html>


### PR DESCRIPTION
Replaces IComparable's old 'pick a version' landing-page template with the canonical auto-redirect-to-`versions/latest/` shape.

Today's behaviour: `https://chris-wolfgang.github.io/IComparable-Extensions/` shows a manual link list (the old version-picker UX). DateTime's canonical: meta-refresh to `versions/latest/` + JS-backup redirect + `<noscript>` link, all delegating to the in-page picker dropdown for version switching.

After this PR merges, the next docfx.yaml run regenerates the gh-pages root with the redirect. Manually dispatchable via:
```
gh workflow run docfx.yaml -R Chris-Wolfgang/IComparable-Extensions -f version=v1.1.1
```

Touches only `.github/version-picker-template.html` — not a workflow file (lives in `.github/`, not `.github/workflows/`) — so unprotected, normal merge.

Same drift exists on every fleet repo that hasn't yet hit a pilot release. Will need to be canonicalized in repo-template + fanned out as a follow-up.