### PR TITLE
D8 canonical: add purple W logo to docs site

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -35,6 +35,7 @@
       {
         "files": [
           "images/**",
+          "logo.svg",
           "public/**",
           "versions.json"
         ]
@@ -48,6 +49,7 @@
     "globalMetadata": {
       "_appName": "",
       "_appTitle": "<title>",
+      "_appLogoPath": "logo.svg",
       "_enableSearch": true,
       "_appFooter": "Made with DocFX <script>(function(){var r='/';if(window.location.hostname.endsWith('.github.io')){var s=window.location.pathname.split('/').filter(Boolean);if(s.length)r='/'+s[0]+'/';}var t=document.createElement('script');t.src=r+'public/version-picker.js';t.async=true;document.head.appendChild(t);})();</script>",
       "_disableSidebar": false,

--- a/docfx_project/logo.svg
+++ b/docfx_project/logo.svg
@@ -1,0 +1,23 @@
+<svg width="48" height="48" viewBox="0 0 48 48"
+     xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <!-- Soft purple glow for dark backgrounds -->
+    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="2" flood-color="#7c23bb" flood-opacity="0.5"/>
+    </filter>
+  </defs>
+  <style>
+    @font-face {
+      font-family: 'DM Serif Display';
+      src: url('https://fonts.gstatic.com/s/dmserifdisplay/v13/-nF6OG414u0gLgBvIEjRpMqB6mM.woff2') format('woff2');
+    }
+    .fancy {
+      font-family: 'DM Serif Display', serif;
+      font-size: 34px;
+      fill: #7c23bb;
+      letter-spacing: 1px;
+      filter: url(#glow);
+    }
+  </style>
+  <text x="7" y="37" class="fancy">W</text>
+</svg>


### PR DESCRIPTION
## Summary

The canonical D8 fanout PR merged without including the purple W logo (`docfx_project/logo.svg`) that should appear in the docs site header next to the repo name (as seen on D20-Dice / DateTime-Extensions).

## Changes

- **`docfx_project/logo.svg`** — adds the canonical purple W icon (identical SVG to every other Wolfgang.* repo)
- **`docfx_project/docfx.json`** — adds `"logo.svg"` to `resource.files` and `"_appLogoPath": "logo.svg"` under `globalMetadata`, so DocFX renders it in the header

## Bypass

Not strictly required — `docfx_project/` is unprotected — but if the Detect .NET Projects guard catches anything, admin-bypass is fine.