### PR TITLE
Fix docfx template + app metadata to match canonical

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -43,12 +43,13 @@
     ],
     "output": "_site",
     "template": [
+      "default",
       "modern",
-      "default"
+      "modern-dark"
     ],
     "globalMetadata": {
-      "_appName": "",
-      "_appTitle": "<title>",
+      "_appName": "Wolfgang.Extensions.IComparable",
+      "_appTitle": "Wolfgang.Extensions.IComparable Documentation",
       "_appLogoPath": "logo.svg",
       "_enableSearch": true,
       "_appFooter": "Made with DocFX <script>(function(){var r='/';if(window.location.hostname.endsWith('.github.io')){var s=window.location.pathname.split('/').filter(Boolean);if(s.length)r='/'+s[0]+'/';}var t=document.createElement('script');t.src=r+'public/version-picker.js';t.async=true;document.head.appendChild(t);})();</script>",


### PR DESCRIPTION
## Summary

Docs site rendered without the version picker, light/dark theme toggle, or the proper header brand. Three drift items in `docfx_project/docfx.json` caused it:

1. **`template` array order was `["modern", "default"]`** — `default` listed after `modern` overrides it, so the deployed site used the legacy DocFX template (loaded `styles/docfx.vendor.min.css` instead of `public/docfx.min.css`). No Bootstrap → no theme toggle, and no DOM anchors for `version-picker.js` to attach to. Canonical is `["default", "modern", "modern-dark"]`.
2. **`_appName` was empty** → header brand area rendered blank.
3. **`_appTitle` was the literal placeholder `"<title>"`**.

Diff is 3 lines in/out.

## Test plan

- [ ] PR checks green
- [ ] Merge → run `docfx.yaml` via `workflow_dispatch` with `deploy_as_latest=true`
- [ ] Verify `https://chris-wolfgang.github.io/IComparable-Extensions/versions/latest/` shows version picker, theme toggle, and the purple-W logo + "Wolfgang.Extensions.IComparable" header text

🤖 Generated with [Claude Code](https://claude.com/claude-code)