### PR TITLE
Stand up benchmarks project + chart workflow

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,103 @@
+name: Benchmarks
+
+# Runs BenchmarkDotNet after a merge to main, then publishes the results to
+# the gh-pages branch under /dev/bench/ where benchmark-action/github-action-benchmark
+# renders an interactive line chart.
+#
+# This workflow is decoupled from PR validation and release: it does NOT gate
+# merging or publishing — it just adds one data point per qualifying push.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - '.github/workflows/benchmarks.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize benchmark publishes so two pushes to main close together can't race
+# on the gh-pages branch. cancel-in-progress: false — every merge represents a
+# meaningful data point, so we queue rather than discard.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Run BenchmarkDotNet & publish chart
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to push the rendered chart + history to the gh-pages branch.
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+
+      - name: Restore
+        run: dotnet restore benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/Wolfgang.Extensions.IComparable.Benchmarks.csproj
+
+      - name: Build (Release)
+        run: dotnet build -c Release --no-restore benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/Wolfgang.Extensions.IComparable.Benchmarks.csproj
+
+      - name: Run benchmarks
+        working-directory: benchmarks/Wolfgang.Extensions.IComparable.Benchmarks
+        # ShortRun keeps total runtime small (~3-5 min). GitHub-hosted runners
+        # are noisy, so chart trends are reliable for allocations and double-digit
+        # time changes; smaller deltas are not.
+        run: dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
+
+      - name: Merge per-class BDN reports
+        id: locate
+        working-directory: benchmarks/Wolfgang.Extensions.IComparable.Benchmarks
+        run: |
+          # BDN's --exporters json writes one *-report-full-compressed.json per
+          # benchmark class. github-action-benchmark consumes a single file, so
+          # we combine the .Benchmarks arrays into one synthetic report.
+          # nullglob: empty match expands to nothing (instead of the literal
+          # pattern), so the explicit "no report found" branch can run before
+          # set -e + pipefail aborts the step.
+          shopt -s nullglob
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BenchmarkDotNet JSON report found"
+            exit 1
+          fi
+          echo "Merging ${#reports[@]} report(s):"
+          printf '  %s\n' "${reports[@]}"
+          jq -s '{
+            Title: "BenchmarkDotNet combined report",
+            HostEnvironmentInfo: .[0].HostEnvironmentInfo,
+            Benchmarks: [.[].Benchmarks[]]
+          }' "${reports[@]}" > benchmarks-result.json
+          echo "report=benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
+
+      - name: Publish chart to gh-pages
+        # Pinned to v1.22.1 commit per repo convention (third-party actions
+        # publishing to gh-pages are pinned by SHA, not mutable tag).
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba  # v1.22.1
+        with:
+          name: BenchmarkDotNet
+          tool: 'benchmarkdotnet'
+          output-file-path: ${{ steps.locate.outputs.report }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Don't fail the workflow if a metric regresses — this is a tracker,
+          # not a gate. Tighten later if the noise floor settles.
+          alert-threshold: '200%'
+          fail-on-alert: false

--- a/IComparable-Extensions.slnx
+++ b/IComparable-Extensions.slnx
@@ -14,6 +14,7 @@
     <File Path=".github/pull_request_template.md" />
   </Folder>
   <Folder Name="/.root/.github/workflows/">
+    <File Path=".github/workflows/benchmarks.yaml" />
     <File Path=".github/workflows/docfx.yaml" />
     <File Path=".github/workflows/pr.yaml" />
     <File Path=".github/workflows/release.yaml" />
@@ -22,6 +23,10 @@
     <File Path=".github/ISSUE_TEMPLATE/BUG_REPORT.yaml" />
     <File Path=".github/ISSUE_TEMPLATE/feature_request.yaml" />
     <File Path=".github/ISSUE_TEMPLATE/maintenance-task.yaml" />
+  </Folder>
+  <Folder Name="/benchmarks/">
+    <File Path="benchmarks/.editorconfig" />
+    <Project Path="benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/Wolfgang.Extensions.IComparable.Benchmarks.csproj" />
   </Folder>
   <Folder Name="/examples/">
     <Project Path="examples/Wolfgang.Extensions.IComparable.DotNet462.Example1/Wolfgang.Extensions.IComparable.DotNet462.Example1.csproj" Id="fbc16a0c-bf3b-4788-b825-9c8e54920bf9" />

--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -1,0 +1,30 @@
+# Benchmark-project analyzer carve-outs (canonical).
+#
+# Benchmark projects inherit `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`
+# from the root `Directory.Build.props` in Release builds — same bar as
+# src/ and tests/. BenchmarkDotNet code patterns (deliberately naive
+# measured code, `[Benchmark]` methods invoked by reflection, fields
+# mutated by harness, etc.) can trip some analyzer rules that would
+# otherwise be reasonable.
+#
+# This file is the canonical home for benchmark-inappropriate
+# analyzer suppressions. As BDN-typical warnings surface during
+# benchmark expansion, add per-rule severity overrides BELOW the
+# `[*.cs]` section header rather than blanket-disabling TWEA on
+# the folder. Properties placed before any section header are
+# ignored by most EditorConfig parsers — keep entries inside
+# `[*.cs]`.
+
+[*.cs]
+
+# S2933: Fields that are only assigned in the constructor should be readonly.
+# Benchmark inputs are stored in instance fields so the JIT can't constant-fold
+# the call site. Future benchmarks will additionally populate fields via
+# [GlobalSetup] (analyzer can't see the attribute-driven assignment), so we
+# carve this out at the folder level rather than per-class.
+dotnet_diagnostic.S2933.severity = none
+
+# Examples (commented out — uncomment as warnings surface):
+# dotnet_diagnostic.CA1822.severity = none      # methods don't access this
+# dotnet_diagnostic.MA0048.severity = none      # File name does not match
+# dotnet_diagnostic.S1144.severity  = none      # Unused private members (reflection)

--- a/benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/IsBetweenBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/IsBetweenBenchmarks.cs
@@ -1,0 +1,67 @@
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Extensions.IComparable;
+
+namespace Wolfgang.Extensions.IComparable.Benchmarks;
+
+/// <summary>
+/// Compares <see cref="IComparableExtensions.IsBetween{T}(T, T, T)"/> against
+/// the hand-written CompareTo idiom for value-type (int) and reference-type
+/// (string) cases. Both bounds and the value are stored in fields to model
+/// realistic call sites where the JIT can't constant-fold the comparison.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class IsBetweenBenchmarks
+{
+    private int _intValueInside  = 5;
+    private int _intValueAtLower = 1;
+    private int _intLower        = 1;
+    private int _intUpper        = 10;
+
+    private string _stringValueInside  = "m";
+    private string _stringValueAtLower = "a";
+    private string _stringLower        = "a";
+    private string _stringUpper        = "z";
+
+    // ----- int — value strictly inside bounds -----
+
+    [Benchmark(Baseline = true)]
+    public bool Manual_Int_Inside() =>
+        _intValueInside.CompareTo(_intLower) > 0 &&
+        _intValueInside.CompareTo(_intUpper) < 0;
+
+    [Benchmark]
+    public bool IsBetween_Int_Inside() =>
+        _intValueInside.IsBetween(_intLower, _intUpper);
+
+    // ----- int — value equal to lower bound (exclusive contract → false) -----
+
+    [Benchmark]
+    public bool Manual_Int_AtLower() =>
+        _intValueAtLower.CompareTo(_intLower) > 0 &&
+        _intValueAtLower.CompareTo(_intUpper) < 0;
+
+    [Benchmark]
+    public bool IsBetween_Int_AtLower() =>
+        _intValueAtLower.IsBetween(_intLower, _intUpper);
+
+    // ----- string — reference-type CompareTo path -----
+
+    [Benchmark]
+    public bool Manual_String_Inside() =>
+        _stringValueInside.CompareTo(_stringLower) > 0 &&
+        _stringValueInside.CompareTo(_stringUpper) < 0;
+
+    [Benchmark]
+    public bool IsBetween_String_Inside() =>
+        _stringValueInside.IsBetween(_stringLower, _stringUpper);
+
+    [Benchmark]
+    public bool Manual_String_AtLower() =>
+        _stringValueAtLower.CompareTo(_stringLower) > 0 &&
+        _stringValueAtLower.CompareTo(_stringUpper) < 0;
+
+    [Benchmark]
+    public bool IsBetween_String_AtLower() =>
+        _stringValueAtLower.IsBetween(_stringLower, _stringUpper);
+}

--- a/benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/IsInRangeBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/IsInRangeBenchmarks.cs
@@ -1,0 +1,67 @@
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Extensions.IComparable;
+
+namespace Wolfgang.Extensions.IComparable.Benchmarks;
+
+/// <summary>
+/// Compares <see cref="IComparableExtensions.IsInRange{T}(T, T, T)"/> against
+/// the hand-written CompareTo idiom. Inclusive contract → checks both boundary
+/// cases (true) and a strictly-inside case for value-type (int) and
+/// reference-type (string) paths.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class IsInRangeBenchmarks
+{
+    private int _intValueInside  = 5;
+    private int _intValueAtLower = 1;
+    private int _intLower        = 1;
+    private int _intUpper        = 10;
+
+    private string _stringValueInside  = "m";
+    private string _stringValueAtLower = "a";
+    private string _stringLower        = "a";
+    private string _stringUpper        = "z";
+
+    // ----- int — value strictly inside bounds -----
+
+    [Benchmark(Baseline = true)]
+    public bool Manual_Int_Inside() =>
+        _intValueInside.CompareTo(_intLower) >= 0 &&
+        _intValueInside.CompareTo(_intUpper) <= 0;
+
+    [Benchmark]
+    public bool IsInRange_Int_Inside() =>
+        _intValueInside.IsInRange(_intLower, _intUpper);
+
+    // ----- int — value equal to lower bound (inclusive contract → true) -----
+
+    [Benchmark]
+    public bool Manual_Int_AtLower() =>
+        _intValueAtLower.CompareTo(_intLower) >= 0 &&
+        _intValueAtLower.CompareTo(_intUpper) <= 0;
+
+    [Benchmark]
+    public bool IsInRange_Int_AtLower() =>
+        _intValueAtLower.IsInRange(_intLower, _intUpper);
+
+    // ----- string — reference-type CompareTo path -----
+
+    [Benchmark]
+    public bool Manual_String_Inside() =>
+        _stringValueInside.CompareTo(_stringLower) >= 0 &&
+        _stringValueInside.CompareTo(_stringUpper) <= 0;
+
+    [Benchmark]
+    public bool IsInRange_String_Inside() =>
+        _stringValueInside.IsInRange(_stringLower, _stringUpper);
+
+    [Benchmark]
+    public bool Manual_String_AtLower() =>
+        _stringValueAtLower.CompareTo(_stringLower) >= 0 &&
+        _stringValueAtLower.CompareTo(_stringUpper) <= 0;
+
+    [Benchmark]
+    public bool IsInRange_String_AtLower() =>
+        _stringValueAtLower.IsInRange(_stringLower, _stringUpper);
+}

--- a/benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/Program.cs
+++ b/benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/Wolfgang.Extensions.IComparable.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/Wolfgang.Extensions.IComparable.Benchmarks.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>14</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IComparable\Wolfgang.Extensions.IComparable.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Closes the three benchmark-related maintenance issues in one PR.

- **Closes #94** — BenchmarkDotNet baseline project at `benchmarks/Wolfgang.Extensions.IComparable.Benchmarks/` with two seed benchmark classes (`IsBetweenBenchmarks`, `IsInRangeBenchmarks`). Each pits the extension method against the hand-written `CompareTo` idiom for value-type (`int`) and reference-type (`string`) inputs, with both strictly-inside and at-boundary cases. Entry point uses `BenchmarkSwitcher.FromAssembly` so `--filter "*"` discovers everything. `[MemoryDiagnoser]` + `[RankColumn]` follow the canonical attribute set from peer extension repos.
- **Closes #95** — `.github/workflows/benchmarks.yaml` runs ShortRun on every push to `main` touching `src/`, `benchmarks/`, or itself (or via `workflow_dispatch`). Per-class JSON reports are merged and published to `gh-pages` `/dev/bench/` via `benchmark-action/github-action-benchmark@v1.22.1` (pinned by SHA). Chart URL after first run: https://chris-wolfgang.github.io/IComparable-Extensions/dev/bench/
- **Closes #116** — `benchmarks/.editorconfig` is the canonical home for benchmark-inappropriate analyzer suppressions. The folder inherits `TreatWarningsAsErrors=true` from `Directory.Build.props` in Release (same bar as `src/` and `tests/`); this file relaxes only what BDN-typical code patterns actually trip. S2933 enabled today (instance fields prevent JIT constant-folding; future `[GlobalSetup]`-populated fields will need it too).

Also:
- Wires `benchmarks/.editorconfig` + the Benchmarks csproj into `IComparable-Extensions.slnx`; lists `benchmarks.yaml` under the workflows folder
- Local Release build clean (0 warnings, 0 errors)

## docfx interaction

Already addressed in canonical `docfx.yaml` (line 521 includes `'dev'` in the keep-list), so release deploys won't wipe benchmark history. No edit needed.

## Test plan

- [ ] PR checks green (Stage 1/2/3 + secrets + DevSkim + CodeQL)
- [ ] After merge, `Benchmarks` workflow fires on the merge commit
- [ ] Chart appears at https://chris-wolfgang.github.io/IComparable-Extensions/dev/bench/
- [ ] Subsequent pushes to `main` touching `src/**` or `benchmarks/**` add data points

🤖 Generated with [Claude Code](https://claude.com/claude-code)